### PR TITLE
Append new optional arguments to client

### DIFF
--- a/graph/client.py
+++ b/graph/client.py
@@ -40,7 +40,7 @@ class client():
                     print(rule['id_rule'] + '(Not selected)')
             return None
 
-    def get_questions(self, separator, separator1):
+    def get_questions(self, separator_rule_ids, separator_not_selected_rule_ids):
         rules = self.search_rules_id()
         if self.show_fail_rules:
             rules = self.get_only_fail_rule(rules)
@@ -48,12 +48,12 @@ class client():
             'type': 'checkbox',
             'message': 'Select rule(s)',
             'name': 'rules',
-            'choices': [separator]
+            'choices': [separator_rule_ids]
         }]
         for rule in rules:
             questions[0]['choices'].append(dict(name=rule['id_rule']))
         if self.show_not_selected_rules:
-            questions[0]['choices'].append(separator1)
+            questions[0]['choices'].append(separator_not_selected_rule_ids)
             for rule in self._get_wanted_not_selected_rules():
                 questions[0]['choices'].append(
                     dict(name=rule['id_rule'], disabled='Not selected'))

--- a/graph/client.py
+++ b/graph/client.py
@@ -28,7 +28,7 @@ class client():
             rules = self.search_rules_id()
             if self.showFailRules:
                 rules = self.get_only_fail_rule(rules)
-            for rule in rule:
+            for rule in rules:
                 print(rule['id_rule'] + r'\b')
             if self.showNotSelectedRules:
                 print('== The not selected rule IDs ==')

--- a/graph/client.py
+++ b/graph/client.py
@@ -134,8 +134,8 @@ class client():
             '--remove-pass-tests',
             action="store_true",
             default=False,
-            help=('If graph have many nodes in graph, you can remove passing'
-                  ' tests for better orientation.(Not implemented)'))
+            help=('Do not display passing tests for better orientation in'
+                  ' graphs that contain a large amount of nodes.(Not implemented)'))
         parser.add_argument("source_filename", help='ARF scan file')
         parser.add_argument(
             "rule_id", help=(

--- a/graph/client.py
+++ b/graph/client.py
@@ -89,6 +89,9 @@ class client():
         parser = argparse.ArgumentParser(
             description='Client for visualization of SCAP rule evaluation results')
 
+        parser.add_argument('--showFailRules', action="store_true", default=False, help='Show all FAIL rules')
+        parser.add_argument('--showNotSelectedRules', action="store_true", default=False, help="Show not selected rules, but you can't visualized this rules.")   
+        parser.add_argument('--removePassTests', action="store_true", default=False, help='If graph have many nodes in graph, you can remove passing tests for better orientation.(not implemented)')
         parser.add_argument("source_filename", help='ARF scan file')
         parser.add_argument(
             "rule_id", help=(

--- a/graph/client.py
+++ b/graph/client.py
@@ -114,7 +114,7 @@ class client():
 
     def parse_arguments(self, args):
         parser = argparse.ArgumentParser(
-            description='Client for visualization scanned rule from Security scan.')
+            description='Client for visualization of SCAP rule evaluation results')
         parser.add_argument(
             '--showFailRules',
             action="store_true",
@@ -124,7 +124,7 @@ class client():
             '--showNotSelectedRules',
             action="store_true",
             default=False,
-            help="Show not selected rules, but you can't visualized this rules.")
+            help="Show notselected rules. These rules will not be visualized.")
         parser.add_argument(
             '--offWebBrowser',
             action="store_true",

--- a/graph/client.py
+++ b/graph/client.py
@@ -25,7 +25,10 @@ class client():
             return prompt(self.get_questions(Separator('= The Rule IDs ='), Separator('= The not selected rule IDs =')))
         except ImportError:
             print('== The Rule IDs ==')
-            for rule in self.search_rules_id():
+            rules = self.search_rules_id()
+            if self.showFailRules:
+                rules = self.get_only_fail_rule(rules)
+            for rule in rule:
                 print(rule['id_rule'] + r'\b')
             if self.showNotSelectedRules:
                 print('== The not selected rule IDs ==')
@@ -35,6 +38,9 @@ class client():
 
     def get_questions(self, separator, separator1):
         rules = self.search_rules_id()
+        if self.showFailRules:
+            rules = self.get_only_fail_rule(rules)
+            print(rules)
         questions = [{
             'type': 'checkbox',
             'message': 'Select rule(s)',
@@ -48,6 +54,9 @@ class client():
             for rule in self._get_wanted_not_selected_rules():
                 questions[0]['choices'].append(dict(name=rule['id_rule'], disabled='Not selected'))
         return questions
+
+    def get_only_fail_rule(self, rules):
+        return list(filter(lambda rule: rule['result'] == 'fail', rules))
 
     def _get_wanted_rules(self):
         return [

--- a/graph/client.py
+++ b/graph/client.py
@@ -10,21 +10,30 @@ import argparse
 class client():
     def __init__(self, args):
         self.arg = self.parse_arguments(args)
+        self.removePassTests=self.arg.removePassTests
+        self.showFailRules=self.arg.showFailRules
+        self.showNotSelectedRules=self.arg.showNotSelectedRules
         self.source_filename = self.arg.source_filename
         self.rule_name = self.arg.rule_id
         self.xml_parser = graph.xml_parser.xml_parser(self.source_filename)
+        if self.removePassTests:
+            raise NotImplementedError('Not implemented!')
 
     def run_gui_and_return_answers(self):
         try:
             from PyInquirer import style_from_dict, Token, prompt, Separator
-            return prompt(self.get_questions(Separator('= The Rule IDs =')))
+            return prompt(self.get_questions(Separator('= The Rule IDs ='), Separator('= The not selected rule IDs =')))
         except ImportError:
             print('== The Rule IDs ==')
             for rule in self.search_rules_id():
                 print(rule['id_rule'] + r'\b')
+            if self.showNotSelectedRules:
+                print('== The not selected rule IDs ==')
+                for rule in self._get_wanted_not_selected_rules():
+                    print(rule['id_rule'] + '(Not selected)')
             return None
 
-    def get_questions(self, separator):
+    def get_questions(self, separator, separator1):
         rules = self.search_rules_id()
         questions = [{
             'type': 'checkbox',
@@ -34,6 +43,10 @@ class client():
         }]
         for rule in rules:
             questions[0]['choices'].append(dict(name=rule['id_rule']))
+        if self.showNotSelectedRules:
+            questions[0]['choices'].append(separator1)
+            for rule in self._get_wanted_not_selected_rules():
+                questions[0]['choices'].append(dict(name=rule['id_rule'], disabled='Not selected'))
         return questions
 
     def _get_wanted_rules(self):
@@ -91,7 +104,7 @@ class client():
 
         parser.add_argument('--showFailRules', action="store_true", default=False, help='Show all FAIL rules')
         parser.add_argument('--showNotSelectedRules', action="store_true", default=False, help="Show not selected rules, but you can't visualized this rules.")   
-        parser.add_argument('--removePassTests', action="store_true", default=False, help='If graph have many nodes in graph, you can remove passing tests for better orientation.(not implemented)')
+        parser.add_argument('--removePassTests', action="store_true", default=False, help='If graph have many nodes in graph, you can remove passing tests for better orientation.(Not implemented)')
         parser.add_argument("source_filename", help='ARF scan file')
         parser.add_argument(
             "rule_id", help=(

--- a/graph/client.py
+++ b/graph/client.py
@@ -10,7 +10,6 @@ import argparse
 class client():
     def __init__(self, args):
         self.arg = self.parse_arguments(args)
-        print(self.arg)
         self.remove_pass_tests = self.arg.remove_pass_tests
         self.show_fail_rules = self.arg.show_fail_rules
         self.show_not_selected_rules = self.arg.show_not_selected_rules

--- a/graph/client.py
+++ b/graph/client.py
@@ -10,10 +10,11 @@ import argparse
 class client():
     def __init__(self, args):
         self.arg = self.parse_arguments(args)
-        self.remove_pass_tests = self.arg.removePassTests
-        self.show_fail_rules = self.arg.showFailRules
-        self.show_not_selected_rules = self.arg.showNotSelectedRules
-        self.off_webbrowser = self.arg.offWebBrowser
+        print(self.arg)
+        self.remove_pass_tests = self.arg.remove_pass_tests
+        self.show_fail_rules = self.arg.show_fail_rules
+        self.show_not_selected_rules = self.arg.show_not_selected_rules
+        self.off_webbrowser = self.arg.off_web_browser
         self.source_filename = self.arg.source_filename
         self.rule_name = self.arg.rule_id
         self.xml_parser = graph.xml_parser.xml_parser(self.source_filename)
@@ -116,22 +117,22 @@ class client():
         parser = argparse.ArgumentParser(
             description='Client for visualization of SCAP rule evaluation results')
         parser.add_argument(
-            '--showFailRules',
+            '--show-fail-rules',
             action="store_true",
             default=False,
             help='Show only FAIL rules')
         parser.add_argument(
-            '--showNotSelectedRules',
+            '--show-not-selected-rules',
             action="store_true",
             default=False,
             help="Show notselected rules. These rules will not be visualized.")
         parser.add_argument(
-            '--offWebBrowser',
+            '--off-web-browser',
             action="store_true",
             default=False,
             help="It does not start the web browser.")
         parser.add_argument(
-            '--removePassTests',
+            '--remove-pass-tests',
             action="store_true",
             default=False,
             help=('If graph have many nodes in graph, you can remove passing'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,24 +9,24 @@ import sys
 
 def get_client(src, rule):
     return graph.client.client(
-        ["--offWebBrowser", tests.any_test_help.get_src(src), rule])
+        ["--off-web-browser", tests.any_test_help.get_src(src), rule])
 
 
 def get_client_with_option_show_fail_rules(src, rule):
     return graph.client.client(
-        ["--showFailRules", tests.any_test_help.get_src(src), rule])
+        ["--show-fail-rules", tests.any_test_help.get_src(src), rule])
 
 
 def get_client_with_option_show_not_selected_rules(src, rule):
     return graph.client.client(
-        ["--showNotSelectedRules", tests.any_test_help.get_src(src), rule])
+        ["--show-not-selected-rules", tests.any_test_help.get_src(src), rule])
 
 
 def get_client_with_option_show_not_selected_rules_and_show_fail_rules(
         src,
         rule):
     return graph.client.client(
-        ["--showNotSelectedRules", "--showFailRules", tests.any_test_help.get_src(src), rule])
+        ["--show-not-selected-rules", "--show-fail-rules", tests.any_test_help.get_src(src), rule])
 
 
 def test_client():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,10 +3,30 @@ import pytest
 import tests.any_test_help
 import re
 import json
+import mock
+import sys
 
 
 def get_client(src, rule):
-    return graph.client.client([tests.any_test_help.get_src(src), rule])
+    return graph.client.client(
+        ["--offWebBrowser", tests.any_test_help.get_src(src), rule])
+
+
+def get_client_with_option_show_fail_rules(src, rule):
+    return graph.client.client(
+        ["--showFailRules", tests.any_test_help.get_src(src), rule])
+
+
+def get_client_with_option_show_not_selected_rules(src, rule):
+    return graph.client.client(
+        ["--showNotSelectedRules", tests.any_test_help.get_src(src), rule])
+
+
+def get_client_with_option_show_not_selected_rules_and_show_fail_rules(
+        src,
+        rule):
+    return graph.client.client(
+        ["--showNotSelectedRules", "--showFailRules", tests.any_test_help.get_src(src), rule])
 
 
 def test_client():
@@ -53,11 +73,28 @@ def test_get_questions():
     client = get_client(src, regex)
     from PyInquirer import Separator
 
-    out = client.get_questions(Separator('= The Rules ID ='))
+    out = client.get_questions(
+        Separator('= The rules ID ='),
+        Separator('= The not selected rules ID ='))
     rule1 = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
     rule2 = 'xccdf_org.ssgproject.content_rule_package_sendmail_removed'
     assert out[0]['choices'][1]['name'] == rule1
     assert out[0]['choices'][2]['name'] == rule2
+
+
+def test_get_questions_with_option_show_fail_rules():
+    src = 'test_data/ssg-fedora-ds-arf.xml'
+    regex = r'_package_\w+_removed'
+    client = get_client_with_option_show_fail_rules(src, regex)
+    from PyInquirer import Separator
+
+    out = client.get_questions(
+        Separator('= The rules ID ='),
+        Separator('= The not selected rules ID ='))
+    rule1 = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
+    assert out[0]['choices'][1]['name'] == rule1
+    with pytest.raises(Exception, match="list index out of range"):
+        assert out[0]['choices'][2]['name'] is None
 
 
 def test_get_wanted_not_selected_rules():
@@ -149,3 +186,74 @@ def test_prepare_graph_with_not_selected_rule():
     src = 'test_data/ssg-fedora-ds-arf.xml'
     rule = 'xccdf_org.ssgproject.content_rule_package_nis_removed'
     try_expection_for_prepare_graph(src, rule, 'not selected')
+
+
+def test_if_not_installed_PyInquirer(capsys):
+    with mock.patch.dict(sys.modules, {'PyInquirer': None}):
+        src = 'test_data/ssg-fedora-ds-arf.xml'
+        regex = r'_package_\w+_removed'
+        client = get_client(src, regex)
+        out = client.run_gui_and_return_answers()
+        assert out is None
+        captured = capsys.readouterr()
+        assert captured.out == (
+            '== The Rule IDs ==\n'
+            'xccdf_org.ssgproject.content_rule_package_abrt_removed\\b\n'
+            'xccdf_org.ssgproject.content_rule_package_sendmail_removed\\b\n')
+
+
+def test_if_not_installed_PyInquirer_with_option_show_fail_rules(capsys):
+    with mock.patch.dict(sys.modules, {'PyInquirer': None}):
+        src = 'test_data/ssg-fedora-ds-arf.xml'
+        regex = r'_package_\w+_removed'
+        client = get_client_with_option_show_fail_rules(src, regex)
+        out = client.run_gui_and_return_answers()
+        assert out is None
+        captured = capsys.readouterr()
+        assert captured.out == (
+            '== The Rule IDs ==\n'
+            'xccdf_org.ssgproject.content_rule_package_abrt_removed\\b\n')
+
+
+def test_if_not_installed_PyInquirer_with_option_show_not_selected_rules(
+        capsys):
+    with mock.patch.dict(sys.modules, {'PyInquirer': None}):
+        src = 'test_data/ssg-fedora-ds-arf.xml'
+        regex = r'_package_\w+_removed'
+        client = get_client_with_option_show_not_selected_rules(src, regex)
+        out = client.run_gui_and_return_answers()
+        assert out is None
+        captured = capsys.readouterr()
+        assert captured.out == (
+            '== The Rule IDs ==\n'
+            'xccdf_org.ssgproject.content_rule_package_abrt_removed\\b\n'
+            'xccdf_org.ssgproject.content_rule_package_sendmail_removed\\b\n'
+            '== The not selected rule IDs ==\n'
+            'xccdf_org.ssgproject.content_rule_package_nis_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_ntpdate_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_telnetd_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_gdm_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_setroubleshoot_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_mcstrans_removed(Not selected)\n')
+
+
+def test_if_not_installed_PyInquirer_with_option_show_not_selected_rules_and_show_fail_rules(
+        capsys):
+    with mock.patch.dict(sys.modules, {'PyInquirer': None}):
+        src = 'test_data/ssg-fedora-ds-arf.xml'
+        regex = r'_package_\w+_removed'
+        client = get_client_with_option_show_not_selected_rules_and_show_fail_rules(
+            src, regex)
+        out = client.run_gui_and_return_answers()
+        assert out is None
+        captured = capsys.readouterr()
+        assert captured.out == (
+            '== The Rule IDs ==\n'
+            'xccdf_org.ssgproject.content_rule_package_abrt_removed\\b\n'
+            '== The not selected rule IDs ==\n'
+            'xccdf_org.ssgproject.content_rule_package_nis_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_ntpdate_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_telnetd_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_gdm_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_setroubleshoot_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_mcstrans_removed(Not selected)\n')


### PR DESCRIPTION
## New optional arguments:
- Optional arguments witch changing the choice of rules:
  - `--showFailRules` - Show only FAIL rules
  - `--showNotSelectedRules` - Show not selected rules, but you can't visualized this rules.
- Optional arguments witch changing behavior of tool:
  - `--offWebBrowser` - It does not start the web browser.
  -  `--removePassTests` - If graph have many nodes in graph, you can remove passing tests for better orientation. (Not implemented)