### PR TITLE
Changed PyInquirer library to inquirer

### DIFF
--- a/oval_graph/client.py
+++ b/oval_graph/client.py
@@ -38,6 +38,10 @@ class client():
                 rules = self.get_only_fail_rule(rules)
             for rule in rules:
                 print(rule['id_rule'] + r'\b')
+            if self.show_not_selected_rules:
+                print('== The not selected rule IDs ==')
+                for rule in self._get_wanted_not_selected_rules():
+                    print(rule['id_rule'] + '(Not selected)')
             return None
 
     def get_questions(self):
@@ -47,6 +51,10 @@ class client():
         choices_ = []
         for rule in rules:
             choices_.append(rule['id_rule'])
+        if self.show_not_selected_rules:
+                print('== The not selected rule IDs ==')
+                for rule in self._get_wanted_not_selected_rules():
+                    print(rule['id_rule'] + '(Not selected)')
         from inquirer.questions import Checkbox as checkbox
         questions = [
             checkbox(

--- a/oval_graph/client.py
+++ b/oval_graph/client.py
@@ -52,9 +52,9 @@ class client():
         for rule in rules:
             choices_.append(rule['id_rule'])
         if self.show_not_selected_rules:
-                print('== The not selected rule IDs ==')
-                for rule in self._get_wanted_not_selected_rules():
-                    print(rule['id_rule'] + '(Not selected)')
+            print('== The not selected rule IDs ==')
+            for rule in self._get_wanted_not_selected_rules():
+                print(rule['id_rule'] + '(Not selected)')
         from inquirer.questions import Checkbox as checkbox
         questions = [
             checkbox(

--- a/oval_graph/client.py
+++ b/oval_graph/client.py
@@ -18,7 +18,8 @@ class client():
         self.source_filename = self.arg.source_filename
         self.tree = self.arg.tree
         self.rule_name = self.arg.rule_id
-        self.xml_parser = oval_graph.xml_parser.xml_parser(self.source_filename)
+        self.xml_parser = oval_graph.xml_parser.xml_parser(
+            self.source_filename)
         if self.tree:
             self.html_interpreter = 'tree_html_interpreter'
         else:
@@ -28,11 +29,8 @@ class client():
 
     def run_gui_and_return_answers(self):
         try:
-            from PyInquirer import style_from_dict, Token, prompt, Separator
-            return prompt(
-                self.get_questions(
-                    Separator('= The Rules IDs ='),
-                    Separator('= The not selected rule IDs =')))
+            import inquirer
+            return inquirer.prompt(self.get_questions())
         except ImportError:
             print('== The Rule IDs ==')
             rules = self.search_rules_id()
@@ -40,32 +38,25 @@ class client():
                 rules = self.get_only_fail_rule(rules)
             for rule in rules:
                 print(rule['id_rule'] + r'\b')
-            if self.show_not_selected_rules:
-                print('== The not selected rule IDs ==')
-                for rule in self._get_wanted_not_selected_rules():
-                    print(rule['id_rule'] + '(Not selected)')
             return None
 
-    def get_questions(
-            self,
-            separator_rule_ids,
-            separator_not_selected_rule_ids):
+    def get_questions(self):
         rules = self.search_rules_id()
         if self.show_fail_rules:
             rules = self.get_only_fail_rule(rules)
-        questions = [{
-            'type': 'checkbox',
-            'message': 'Select rule(s)',
-            'name': 'rules',
-            'choices': [separator_rule_ids]
-        }]
+        choices_ = []
         for rule in rules:
-            questions[0]['choices'].append(dict(name=rule['id_rule']))
-        if self.show_not_selected_rules:
-            questions[0]['choices'].append(separator_not_selected_rule_ids)
-            for rule in self._get_wanted_not_selected_rules():
-                questions[0]['choices'].append(
-                    dict(name=rule['id_rule'], disabled='Not selected'))
+            choices_.append(rule['id_rule'])
+        from inquirer.questions import Checkbox as checkbox
+        questions = [
+            checkbox(
+                'rules',
+                message=(
+                    "= The Rules IDs = (move - UP and DOWN arrows,"
+                    " select - SPACE or LEFT and RIGHT arrows, submit - ENTER)"),
+                choices=choices_,
+            ),
+        ]
         return questions
 
     def get_only_fail_rule(self, rules):
@@ -92,7 +83,7 @@ class client():
                  " wasn't a part of the executed profile"
                  " and therefore it wasn't evaluated "
                  "during the scan.")
-               .format(notselected_rules[0]['id_rule']))
+                .format(notselected_rules[0]['id_rule']))
         elif not notselected_rules and not rules:
             raise ValueError('err- 404 rule not found!')
         else:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -36,10 +36,10 @@ def get_client_with_option_show_not_selected_rules_and_show_fail_rules(
         src,
         rule):
     return oval_graph.client.client(["--show-not-selected-rules",
-                                "--show-fail-rules",
-                                "--off-web-browser",
-                                tests.any_test_help.get_src(src),
-                                rule])
+                                     "--show-fail-rules",
+                                     "--off-web-browser",
+                                     tests.any_test_help.get_src(src),
+                                     rule])
 
 
 def test_client():
@@ -91,61 +91,63 @@ def test_get_questions():
     src = 'test_data/ssg-fedora-ds-arf.xml'
     regex = r'_package_\w+_removed'
     client = get_client(src, regex)
-    from PyInquirer import Separator
-
-    out = client.get_questions(
-        Separator('= The rules ID ='),
-        Separator('= The not selected rules ID ='))
+    out = client.get_questions()[0].choices
     rule1 = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
     rule2 = 'xccdf_org.ssgproject.content_rule_package_sendmail_removed'
-    assert out[0]['choices'][1]['name'] == rule1
-    assert out[0]['choices'][2]['name'] == rule2
+    assert out[0] == rule1
+    assert out[1] == rule2
 
 
-def test_get_questions_not_selected():
+def test_get_questions_not_selected(capsys):
     src = 'test_data/ssg-fedora-ds-arf.xml'
     regex = r'_package_\w+_removed'
     client = get_client_with_option_show_not_selected_rules(src, regex)
-    from PyInquirer import Separator
+    out = client.get_questions()[0].choices
+    outResult = [
+        'xccdf_org.ssgproject.content_rule_package_abrt_removed',
+        'xccdf_org.ssgproject.content_rule_package_sendmail_removed']
+    assert out == outResult
+    captured = capsys.readouterr()
+    assert captured.out == (
+        '== The not selected rule IDs ==\n'
+        'xccdf_org.ssgproject.content_rule_package_nis_removed(Not selected)\n'
+        'xccdf_org.ssgproject.content_rule_package_ntpdate_removed(Not selected)\n'
+        'xccdf_org.ssgproject.content_rule_package_telnetd_removed(Not selected)\n'
+        'xccdf_org.ssgproject.content_rule_package_gdm_removed(Not selected)\n'
+        'xccdf_org.ssgproject.content_rule_package_setroubleshoot_removed(Not selected)\n'
+        'xccdf_org.ssgproject.content_rule_package_mcstrans_removed(Not selected)\n')
 
-    out = client.get_questions(
-        Separator('= The rules ID ='),
-        Separator('= The not selected rules ID ='))
-    rule1 = 'xccdf_org.ssgproject.content_rule_package_setroubleshoot_removed'
-    rule2 = 'xccdf_org.ssgproject.content_rule_package_mcstrans_removed'
-    assert out[0]['choices'][-2]['name'] == rule1
-    assert out[0]['choices'][-1]['name'] == rule2
 
-
-def test_get_questions_not_selected_and_show_fail_rules():
+def test_get_questions_not_selected_and_show_fail_rules(capsys):
     src = 'test_data/ssg-fedora-ds-arf.xml'
     regex = r'_package_\w+_removed'
     client = get_client_with_option_show_not_selected_rules_and_show_fail_rules(
         src, regex)
-    from PyInquirer import Separator
-
-    out = client.get_questions(
-        Separator('= The rules ID ='),
-        Separator('= The not selected rules ID ='))
-    rule1 = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
-    rule2 = 'xccdf_org.ssgproject.content_rule_package_mcstrans_removed'
-    assert out[0]['choices'][1]['name'] == rule1
-    assert out[0]['choices'][-1]['name'] == rule2
+    out = client.get_questions()[0].choices
+    outResult = ['xccdf_org.ssgproject.content_rule_package_abrt_removed']
+    assert out == outResult
+    assert len(out) == 1
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert captured.out == (
+        '== The not selected rule IDs ==\n'
+        'xccdf_org.ssgproject.content_rule_package_nis_removed(Not selected)\n'
+        'xccdf_org.ssgproject.content_rule_package_ntpdate_removed(Not selected)\n'
+        'xccdf_org.ssgproject.content_rule_package_telnetd_removed(Not selected)\n'
+        'xccdf_org.ssgproject.content_rule_package_gdm_removed(Not selected)\n'
+        'xccdf_org.ssgproject.content_rule_package_setroubleshoot_removed(Not selected)\n'
+        'xccdf_org.ssgproject.content_rule_package_mcstrans_removed(Not selected)\n')
 
 
 def test_get_questions_with_option_show_fail_rules():
     src = 'test_data/ssg-fedora-ds-arf.xml'
     regex = r'_package_\w+_removed'
     client = get_client_with_option_show_fail_rules(src, regex)
-    from PyInquirer import Separator
-
-    out = client.get_questions(
-        Separator('= The rules ID ='),
-        Separator('= The not selected rules ID ='))
+    out = client.get_questions()[0].choices
     rule1 = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
-    assert out[0]['choices'][1]['name'] == rule1
+    assert out[0] == rule1
     with pytest.raises(Exception, match="list index out of range"):
-        assert out[0]['choices'][2]['name'] is None
+        assert out[2] is None
 
 
 def test_get_wanted_not_selected_rules():
@@ -252,8 +254,8 @@ def test_prepare_graph_with_not_selected_rule():
     try_expection_for_prepare_graph(src, rule, 'not selected')
 
 
-def test_if_not_installed_PyInquirer(capsys):
-    with mock.patch.dict(sys.modules, {'PyInquirer': None}):
+def test_if_not_installed_inquirer(capsys):
+    with mock.patch.dict(sys.modules, {'inquirer': None}):
         src = 'test_data/ssg-fedora-ds-arf.xml'
         regex = r'_package_\w+_removed'
         client = get_client(src, regex)
@@ -266,8 +268,8 @@ def test_if_not_installed_PyInquirer(capsys):
             'xccdf_org.ssgproject.content_rule_package_sendmail_removed\\b\n')
 
 
-def test_if_not_installed_PyInquirer_with_option_show_fail_rules(capsys):
-    with mock.patch.dict(sys.modules, {'PyInquirer': None}):
+def test_if_not_installed_inquirer_with_option_show_fail_rules(capsys):
+    with mock.patch.dict(sys.modules, {'inquirer': None}):
         src = 'test_data/ssg-fedora-ds-arf.xml'
         regex = r'_package_\w+_removed'
         client = get_client_with_option_show_fail_rules(src, regex)
@@ -279,9 +281,9 @@ def test_if_not_installed_PyInquirer_with_option_show_fail_rules(capsys):
             'xccdf_org.ssgproject.content_rule_package_abrt_removed\\b\n')
 
 
-def test_if_not_installed_PyInquirer_with_option_show_not_selected_rules(
+def test_if_not_installed_inquirer_with_option_show_not_selected_rules(
         capsys):
-    with mock.patch.dict(sys.modules, {'PyInquirer': None}):
+    with mock.patch.dict(sys.modules, {'inquirer': None}):
         src = 'test_data/ssg-fedora-ds-arf.xml'
         regex = r'_package_\w+_removed'
         client = get_client_with_option_show_not_selected_rules(src, regex)
@@ -301,9 +303,9 @@ def test_if_not_installed_PyInquirer_with_option_show_not_selected_rules(
             'xccdf_org.ssgproject.content_rule_package_mcstrans_removed(Not selected)\n')
 
 
-def test_if_not_installed_PyInquirer_with_option_show_not_selected_rules_and_show_fail_rules(
+def test_if_not_installed_inquirer_with_option_show_not_selected_rules_and_show_fail_rules(
         capsys):
-    with mock.patch.dict(sys.modules, {'PyInquirer': None}):
+    with mock.patch.dict(sys.modules, {'inquirer': None}):
         src = 'test_data/ssg-fedora-ds-arf.xml'
         regex = r'_package_\w+_removed'
         client = get_client_with_option_show_not_selected_rules_and_show_fail_rules(


### PR DESCRIPTION
This PR changes PyInquirer library to inquirer. Because PyInquirer has problems with installation.