### PR TITLE
Add command arf-to-json

### DIFF
--- a/oval_graph/arf_to_json.py
+++ b/oval_graph/arf_to_json.py
@@ -1,0 +1,35 @@
+import webbrowser
+import json
+import os
+import shutil
+import pprint
+from datetime import datetime
+
+
+from .converter import Converter
+from .client import Client
+
+
+class ArfToJson(Client):
+
+    def create_dict_of_rule(self, rule_id):
+        return self.xml_parser.get_oval_tree(rule_id).save_tree_to_dict()
+
+    def save_dict_as_json(self, dict_, src):
+        with open(src + '.json', "w+") as f:
+            json.dump(dict_, f)
+
+    def prepare_data(self, rules):
+        try:
+            out = []
+            for rule in rules['rules']:
+                oval_tree_dict = self.create_dict_of_rule(rule)
+                if self.out is not None:
+                    src = self.get_save_src(rule)
+                    self.save_dict_as_json(oval_tree_dict, src)
+                    out.append(src)
+                else:
+                    print(str(json.dumps(oval_tree_dict, sort_keys=False, indent=4)))
+            return out
+        except Exception as error:
+            raise ValueError('Rule: "{}" Error: "{}"'.format(rule, error))

--- a/oval_graph/client.py
+++ b/oval_graph/client.py
@@ -119,7 +119,7 @@ class Client():
                 shutil.copy2(s, d)
 
     def get_save_src(self, rule):
-        date = str(datetime.now().strftime("_%d-%m-%Y_%H:%M:%S"))
+        date = str(datetime.now().strftime("-%d_%m_%Y-%H_%M_%S"))
         if self.out is not None:
             if not os.path.isdir(self.out):
                 os.mkdir(self.out)

--- a/oval_graph/command_line.py
+++ b/oval_graph/command_line.py
@@ -1,6 +1,7 @@
 import sys
 
 from .arf_to_html import ArfToHtml
+from .arf_to_json import ArfToJson
 
 
 def print_where_is_saved_result(results_src):
@@ -9,8 +10,21 @@ def print_where_is_saved_result(results_src):
         print(src)
 
 
-def arf_to_html():
-    client = ArfToHtml(sys.argv[1:])
+def arf_to_graph(args=None):
+    if args is not None:
+        main(ArfToHtml(args))
+    else:
+        main(ArfToHtml(sys.argv[1:]))
+
+
+def arf_to_json(args=None):
+    if args is not None:
+        main(ArfToJson(args))
+    else:
+        main(ArfToJson(sys.argv[1:]))
+
+
+def main(client):
     rules = client.search_rules_id()
     if len(rules) > 1:
         answers = client.run_gui_and_return_answers()
@@ -23,4 +37,9 @@ def arf_to_html():
 
 
 if __name__ == '__main__':
-    arf_to_html()
+    if sys.argv[1] == "arf-to-graph":
+        arf_to_graph(sys.argv[2:])
+    if sys.argv[1] == "arf-to-json":
+        arf_to_json(sys.argv[2:])
+    else:
+        print("err- Bad command!")

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,10 @@ setup(name='oval_graph',
       include_package_data=True,
       zip_safe=False,
       entry_points={
-          'console_scripts': ['arf-to-graph=oval_graph.command_line:main'],
+          'console_scripts': [
+              'arf-to-graph=oval_graph.command_line:arf_to_graph',
+              'arf-to-json=oval_graph.command_line:arf_to_json',
+          ],
       },
       python_requires='>=3.6',
       )

--- a/tests/any_test_help.py
+++ b/tests/any_test_help.py
@@ -118,4 +118,10 @@ def compare_results_js(result):
         os.path.join(result, 'data.js'))
     referenc_result = any_get_tested_file(
         'test_data/referenc_result_data_tree.js')
+
+
+def compare_results_json(result):
+    result = any_get_test_data_json(result + '.json')
+    referenc_result = any_get_test_data_json(
+        'test_data/referenc_result_data_json.json')
     assert result == referenc_result

--- a/tests/test_arf_to_json.py
+++ b/tests/test_arf_to_json.py
@@ -1,0 +1,87 @@
+import pytest
+import tempfile
+import os
+import uuid
+
+
+from oval_graph.arf_to_json import ArfToJson
+import tests.any_test_help
+
+
+def get_client_arf_to_json(src, rule):
+    return ArfToJson(
+        [tests.any_test_help.get_src(src), rule])
+
+
+def get_client_arf_to_json_with_define_dest(src, rule):
+    return ArfToJson(["--out",
+                      tests.any_test_help.get_src(os.path.join(tempfile.gettempdir(),
+                                                               str(uuid.uuid4()))),
+                      tests.any_test_help.get_src(src),
+                      rule])
+
+
+def try_expection_for_prepare_graph(src, rule, err):
+    client = get_client_arf_to_json(src, rule)
+    rules = {'rules': [rule]}
+    with pytest.raises(Exception, match=err):
+        assert client.prepare_data(rules)
+
+
+def test_prepare_graph_with_non_existent_rule():
+    src = 'test_data/ssg-fedora-ds-arf.xml'
+    rule = 'non-existent_rule'
+    try_expection_for_prepare_graph(src, rule, '404')
+
+
+def test_prepare_graph_with_not_selected_rule():
+    src = 'test_data/ssg-fedora-ds-arf.xml'
+    rule = 'xccdf_org.ssgproject.content_rule_package_nis_removed'
+    try_expection_for_prepare_graph(src, rule, 'not selected')
+
+
+def test_prepare_json(capsys):
+    src = 'test_data/ssg-fedora-ds-arf.xml'
+    rule = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
+    client = get_client_arf_to_json(src, rule)
+    rules = {'rules': [rule]}
+    results_src = client.prepare_data(rules)
+    assert not results_src
+    captured = capsys.readouterr()
+    print(repr(captured.out))
+    assert captured.out == (
+        '{\n'
+        '    "node_id": "xccdf_org.ssgproject.content_rule_package_abrt_removed",\n'
+        '    "type": "operator",\n'
+        '    "value": "and",\n'
+        '    "negation": false,\n'
+        '    "comment": "Package abrt Removed",\n'
+        '    "child": [\n'
+        '        {\n'
+        '            "node_id": "oval:ssg-package_abrt_removed:def:1",\n'
+        '            "type": "operator",\n'
+        '            "value": "and",\n'
+        '            "negation": false,\n'
+        '            "comment": null,\n'
+        '            "child": [\n'
+        '                {\n'
+        '                    "node_id": "oval:ssg-test_package_abrt_removed:tst:1",\n'
+        '                    "type": "value",\n'
+        '                    "value": "false",\n'
+        '                    "negation": false,\n'
+        '                    "comment": "package abrt is removed",\n'
+        '                    "child": null\n'
+        '                }\n'
+        '            ]\n'
+        '        }\n'
+        '    ]\n'
+        '}\n')
+
+
+def test_prepare_json_and_save_in_defined_destination():
+    src = 'test_data/ssg-fedora-ds-arf.xml'
+    rule = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
+    client = get_client_arf_to_json_with_define_dest(src, rule)
+    rules = {'rules': [rule]}
+    results_src = client.prepare_data(rules)
+    tests.any_test_help.compare_results_json(results_src[0])

--- a/tests/test_data/referenc_result_data_json.json
+++ b/tests/test_data/referenc_result_data_json.json
@@ -1,0 +1,26 @@
+{
+    "node_id": "xccdf_org.ssgproject.content_rule_package_abrt_removed",
+    "type": "operator",
+    "value": "and",
+    "negation": false,
+    "comment": "Package abrt Removed",
+    "child": [
+        {
+            "node_id": "oval:ssg-package_abrt_removed:def:1",
+            "type": "operator",
+            "value": "and",
+            "negation": false,
+            "comment": null,
+            "child": [
+                {
+                    "node_id": "oval:ssg-test_package_abrt_removed:tst:1",
+                    "type": "value",
+                    "value": "false",
+                    "negation": false,
+                    "comment": "package abrt is removed",
+                    "child": null
+                }
+            ]
+        }
+    ]
+}                                                                                                                                                                                                                                 


### PR DESCRIPTION
This PR include new command `arf-to-json` which transform rule form arf to json.

Fixes: #39 
Restore to graph command will be append in next PR.