### PR TITLE
Output to single JSON file

### DIFF
--- a/oval_graph/arf_to_json.py
+++ b/oval_graph/arf_to_json.py
@@ -45,3 +45,10 @@ class ArfToJson(Client):
             return out
         except Exception as error:
             raise ValueError('Rule: "{}" Error: "{}"'.format(rule, error))
+
+    def prepare_parser_out(self):
+        self.parser.add_argument(
+            '--output',
+            action="store",
+            default=None,
+            help="The file where to save output.")

--- a/oval_graph/arf_to_json.py
+++ b/oval_graph/arf_to_json.py
@@ -48,6 +48,7 @@ class ArfToJson(Client):
 
     def prepare_parser_out(self):
         self.parser.add_argument(
+            '-o', 
             '--output',
             action="store",
             default=None,

--- a/oval_graph/client.py
+++ b/oval_graph/client.py
@@ -176,8 +176,16 @@ class Client():
 
     def parse_arguments(self, args):
         self.prepare_parser()
+        self.prepare_parser_out()
         args = self.parser.parse_args(args)
         return args
+
+    def prepare_parser_out(self):
+        self.parser.add_argument(
+            '--output',
+            action="store",
+            default=None,
+            help="The directory where to save output files.")
 
     def prepare_parser(self):
         self.parser = argparse.ArgumentParser(
@@ -192,11 +200,6 @@ class Client():
             action="store_true",
             default=False,
             help="Show notselected rules. These rules will not be visualized.")
-        self.parser.add_argument(
-            '--output',
-            action="store",
-            default=None,
-            help="The directory where to save output files.")
         self.parser.add_argument(
             '--all',
             action="store_true",

--- a/oval_graph/client.py
+++ b/oval_graph/client.py
@@ -182,6 +182,7 @@ class Client():
 
     def prepare_parser_out(self):
         self.parser.add_argument(
+            '-o',
             '--output',
             action="store",
             default=None,

--- a/oval_graph/json_to_html.py
+++ b/oval_graph/json_to_html.py
@@ -58,13 +58,12 @@ class JsonToHtml(Client):
             out = []
             for rule in rules["rules"]:
                 self.oval_tree = self.load_json_to_oval_tree(rule)
-                rule_name = self.oval_tree.node_id
                 oval_tree_dict = self.create_dict_of_oval_node(self.oval_tree)
-                src = self.get_save_src(rule_name)
+                src = self.get_save_src(rule.replace('graph-of-', '') + "-")
                 self.copy_interpreter(src)
                 self.save_dict(oval_tree_dict, src)
                 self.open_web_browser(src)
-                print('Rule "{}" done!'.format(rule_name))
+                print('Rule "{}" done!'.format(rule))
                 out.append(src)
             return out
         except Exception as error:

--- a/oval_graph/json_to_html.py
+++ b/oval_graph/json_to_html.py
@@ -80,11 +80,6 @@ class JsonToHtml(Client):
             default=False,
             help="It does not start the web browser.")
         self.parser.add_argument(
-            '--output',
-            action="store",
-            default=None,
-            help="Save the output files where it is defined.")
-        self.parser.add_argument(
             '--all',
             action="store_true",
             default=False,

--- a/tests/any_test_help.py
+++ b/tests/any_test_help.py
@@ -121,7 +121,8 @@ def compare_results_js(result):
 
 
 def compare_results_json(result):
-    result = any_get_test_data_json(result + '.json')
+    result = any_get_test_data_json(result)
     referenc_result = any_get_test_data_json(
         'test_data/referenc_result_data_json.json')
-    assert result == referenc_result
+    assert result[list(result.keys())[
+        0]] == referenc_result["xccdf_org.ssgproject.content_rule_package_abrt_removed"]

--- a/tests/test_arf_to_json.py
+++ b/tests/test_arf_to_json.py
@@ -2,7 +2,9 @@ import pytest
 import tempfile
 import os
 import uuid
-
+import json
+from datetime import datetime
+import time
 
 from oval_graph.arf_to_json import ArfToJson
 import tests.any_test_help
@@ -16,7 +18,7 @@ def get_client_arf_to_json(src, rule):
 def get_client_arf_to_json_with_define_dest(src, rule):
     return ArfToJson(["--output",
                       tests.any_test_help.get_src(os.path.join(tempfile.gettempdir(),
-                                                               str(uuid.uuid4()))),
+                                                               str(uuid.uuid4()) + ".json")),
                       tests.any_test_help.get_src(src),
                       rule])
 
@@ -45,13 +47,16 @@ def test_prepare_json(capsys):
     rule = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
     client = get_client_arf_to_json(src, rule)
     rules = {'rules': [rule]}
+    date = str(datetime.now().strftime("-%d_%m_%Y-%H_%M_%S"))
     results_src = client.prepare_data(rules)
     assert not results_src
     captured = capsys.readouterr()
     print(repr(captured.out))
     assert captured.out == (
         '{\n'
-        '    "xccdf_org.ssgproject.content_rule_package_abrt_removed": {\n'
+        '    "graph-of-xccdf_org.ssgproject.content_rule_package_abrt_removed' +
+        date +
+        '": {\n'
         '        "node_id": "xccdf_org.ssgproject.content_rule_package_abrt_removed",\n'
         '        "type": "operator",\n'
         '        "value": "and",\n'
@@ -87,3 +92,59 @@ def test_prepare_json_and_save_in_defined_destination():
     rules = {'rules': [rule]}
     results_src = client.prepare_data(rules)
     tests.any_test_help.compare_results_json(results_src[0])
+
+
+def test_is_empty_file():
+    src = 'test_data/ssg-fedora-ds-arf.xml'
+    rule = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
+    client = get_client_arf_to_json_with_define_dest(src, rule)
+    empty_file_src = tests.any_test_help.get_src('test_data/empty_file.json')
+    assert client.file_is_empty(empty_file_src)
+
+
+def test_if_file_has_content():
+    src = 'test_data/ssg-fedora-ds-arf.xml'
+    rule = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
+    client = get_client_arf_to_json_with_define_dest(src, rule)
+    file_src = tests.any_test_help.get_src('test_data/JsTree_json0.json')
+    assert not client.file_is_empty(file_src)
+
+
+def test_creation_json_with_two_more_rule():
+    src = 'test_data/ssg-fedora-ds-arf.xml'
+    rule = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
+    client = get_client_arf_to_json_with_define_dest(src, rule)
+    rules = {'rules': [rule]}
+    result_src = client.prepare_data(rules)
+    time.sleep(1)  # wait for change time in saved rule name
+    result_src_second_rule = client.prepare_data(rules)
+    assert result_src == result_src_second_rule
+    data = None
+    with open(result_src[-1], 'r') as f:
+        data = json.load(f)
+    rules_id = list(data.keys())
+    assert len(rules_id) == 2
+    assert data[rules_id[0]] == data[rules_id[1]]
+    referenc_result = tests.any_test_help.any_get_test_data_json(
+        'test_data/referenc_result_data_json.json')
+    assert referenc_result[
+        "xccdf_org.ssgproject.content_rule_package_abrt_removed"] == data[rules_id[0]]
+
+
+def test_creation_json_two_selected_rules():
+    src = 'test_data/ssg-fedora-ds-arf.xml'
+    rule = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
+    rule1 = 'xccdf_org.ssgproject.content_rule_disable_host_auth'
+    client = get_client_arf_to_json_with_define_dest(src, rule)
+    rules = {'rules': [rule, rule1]}
+    result_src = client.prepare_data(rules)
+    data = None
+    with open(result_src[-1], 'r') as f:
+        data = json.load(f)
+    rules_id = list(data.keys())
+    assert len(rules_id) == 2
+    referenc_result = tests.any_test_help.any_get_test_data_json(
+        'test_data/referenc_result_data_json.json')
+    assert referenc_result[
+        "xccdf_org.ssgproject.content_rule_package_abrt_removed"] == data[rules_id[0]]
+    assert rule1 in rules_id[1]


### PR DESCRIPTION
This PR change function of parameter ```--out``` in command ```arf-to-json```.  User can store rules in one json file. 
Fixes: #67 