### PR TITLE
New parameter in json-to-graph

### DIFF
--- a/oval_graph/arf_to_html.py
+++ b/oval_graph/arf_to_html.py
@@ -11,6 +11,14 @@ class ArfToHtml(Client):
         self.show_fail_rules = self.arg.show_fail_rules
         self.show_not_selected_rules = self.arg.show_not_selected_rules
 
+    def _get_message(self):
+        MESSAGES = {
+            'description': 'Client for visualization of SCAP rule evaluation results',
+            '--output': 'The directory where to save output directory with files.',
+            'source_filename': 'ARF scan file',
+        }
+        return MESSAGES
+
     def prepare_data(self, rules):
         try:
             out = []
@@ -43,11 +51,3 @@ class ArfToHtml(Client):
             action="store_true",
             default=False,
             help="Show notselected rules. These rules will not be visualized.")
-
-    def get_message(self, parameter):
-        messages = {
-            'description': 'Client for visualization of SCAP rule evaluation results',
-            '--output': 'The directory where to save output directory with files.',
-            'source_filename': 'ARF scan file',
-        }
-        return messages[parameter]

--- a/oval_graph/arf_to_html.py
+++ b/oval_graph/arf_to_html.py
@@ -8,6 +8,8 @@ class ArfToHtml(Client):
     def __init__(self, args):
         super().__init__(args)
         self.off_webbrowser = self.arg.off_web_browser
+        self.show_fail_rules = self.arg.show_fail_rules
+        self.show_not_selected_rules = self.arg.show_not_selected_rules
 
     def prepare_data(self, rules):
         try:
@@ -31,3 +33,21 @@ class ArfToHtml(Client):
             action="store_true",
             default=False,
             help="It does not start the web browser.")
+        self.parser.add_argument(
+            '--show-fail-rules',
+            action="store_true",
+            default=False,
+            help="Show only FAIL rules")
+        self.parser.add_argument(
+            '--show-not-selected-rules',
+            action="store_true",
+            default=False,
+            help="Show notselected rules. These rules will not be visualized.")
+
+    def get_message(self, parameter):
+        messages = {
+            'description': 'Client for visualization of SCAP rule evaluation results',
+            '--output': 'The directory where to save output directory with files.',
+            'source_filename': 'ARF scan file',
+        }
+        return messages[parameter]

--- a/oval_graph/arf_to_json.py
+++ b/oval_graph/arf_to_json.py
@@ -12,6 +12,11 @@ from .client import Client
 
 
 class ArfToJson(Client):
+    def __init__(self, args):
+        super().__init__(args)
+        self.show_fail_rules = self.arg.show_fail_rules
+        self.show_not_selected_rules = self.arg.show_not_selected_rules
+
     def create_dict_of_rule(self, rule_id):
         return self.xml_parser.get_oval_tree(rule_id).save_tree_to_dict()
 
@@ -46,10 +51,23 @@ class ArfToJson(Client):
         except Exception as error:
             raise ValueError('Rule: "{}" Error: "{}"'.format(rule, error))
 
-    def prepare_parser_out(self):
+    def prepare_parser(self):
+        super().prepare_parser()
         self.parser.add_argument(
-            '-o', 
-            '--output',
-            action="store",
-            default=None,
-            help="The file where to save output.")
+            '--show-fail-rules',
+            action="store_true",
+            default=False,
+            help="Show only FAIL rules")
+        self.parser.add_argument(
+            '--show-not-selected-rules',
+            action="store_true",
+            default=False,
+            help="Show notselected rules. These rules will not be visualized.")
+
+    def get_message(self, parameter):
+        messages = {
+            'description': 'Client for generating JSON of SCAP rule evaluation results',
+            '--output': 'The file where to save output.',
+            'source_filename': 'ARF scan file',
+        }
+        return messages[parameter]

--- a/oval_graph/arf_to_json.py
+++ b/oval_graph/arf_to_json.py
@@ -17,6 +17,14 @@ class ArfToJson(Client):
         self.show_fail_rules = self.arg.show_fail_rules
         self.show_not_selected_rules = self.arg.show_not_selected_rules
 
+    def _get_message(self):
+        MESSAGES = {
+            'description': 'Client for generating JSON of SCAP rule evaluation results',
+            '--output': 'The file where to save output.',
+            'source_filename': 'ARF scan file',
+        }
+        return MESSAGES
+
     def create_dict_of_rule(self, rule_id):
         return self.xml_parser.get_oval_tree(rule_id).save_tree_to_dict()
 
@@ -63,11 +71,3 @@ class ArfToJson(Client):
             action="store_true",
             default=False,
             help="Show notselected rules. These rules will not be visualized.")
-
-    def get_message(self, parameter):
-        messages = {
-            'description': 'Client for generating JSON of SCAP rule evaluation results',
-            '--output': 'The file where to save output.',
-            'source_filename': 'ARF scan file',
-        }
-        return messages[parameter]

--- a/oval_graph/client.py
+++ b/oval_graph/client.py
@@ -15,6 +15,7 @@ from .converter import Converter
 class Client():
     def __init__(self, args):
         self.parser = None
+        self.MESSAGES = self._get_message()
         self.arg = self.parse_arguments(args)
         self.remove_pass_tests = self.arg.remove_pass_tests
         self.source_filename = self.arg.source_filename
@@ -28,6 +29,15 @@ class Client():
             self.source_filename)
         if self.remove_pass_tests:
             raise NotImplementedError('Not implemented!')
+
+    def _get_message(self):
+        MESSAGES = {
+            'description': '',
+            '--output': '',
+            'source_filename': '',
+        }
+        return MESSAGES
+
 
     def run_gui_and_return_answers(self):
         if self.isatty:
@@ -181,7 +191,7 @@ class Client():
 
     def prepare_parser(self):
         self.parser = argparse.ArgumentParser(
-            description=self.get_message('description'))
+            description=self.MESSAGES.get('description'))
         self.parser.add_argument(
             '--all',
             action="store_true",
@@ -199,22 +209,13 @@ class Client():
             '--output',
             action="store",
             default=None,
-            help=self.get_message('--output'))
+            help=self.MESSAGES.get('--output'))
         self.parser.add_argument(
             "source_filename",
-            help=self.get_message('source_filename'))
+            help=self.MESSAGES.get('source_filename'))
         self.parser.add_argument(
             "rule_id", help=(
                 "Rule ID to be visualized. A part from the full rule ID"
                 " a part of the ID or a regular expression can be used."
                 " If brackets are used in the regular expression "
                 "the regular expression must be quoted."))
-
-# Message text is defined in children of Client.
-    def get_message(self, parameter):
-        messages = {
-            'description': '',
-            '--output': '',
-            'source_filename': '',
-        }
-        return messages[parameter]

--- a/oval_graph/client.py
+++ b/oval_graph/client.py
@@ -17,13 +17,13 @@ class Client():
         self.parser = None
         self.arg = self.parse_arguments(args)
         self.remove_pass_tests = self.arg.remove_pass_tests
-        self.show_fail_rules = self.arg.show_fail_rules
-        self.show_not_selected_rules = self.arg.show_not_selected_rules
         self.source_filename = self.arg.source_filename
         self.rule_name = self.arg.rule_id
         self.out = self.arg.output
         self.all_rules = self.arg.all
         self.isatty = sys.stdout.isatty()
+        self.show_fail_rules = False
+        self.show_not_selected_rules = False
         self.xml_parser = XmlParser(
             self.source_filename)
         if self.remove_pass_tests:
@@ -176,31 +176,12 @@ class Client():
 
     def parse_arguments(self, args):
         self.prepare_parser()
-        self.prepare_parser_out()
         args = self.parser.parse_args(args)
         return args
 
-    def prepare_parser_out(self):
-        self.parser.add_argument(
-            '-o',
-            '--output',
-            action="store",
-            default=None,
-            help="The directory where to save output files.")
-
     def prepare_parser(self):
         self.parser = argparse.ArgumentParser(
-            description="Client for visualization of SCAP rule evaluation results")
-        self.parser.add_argument(
-            '--show-fail-rules',
-            action="store_true",
-            default=False,
-            help="Show only FAIL rules")
-        self.parser.add_argument(
-            '--show-not-selected-rules',
-            action="store_true",
-            default=False,
-            help="Show notselected rules. These rules will not be visualized.")
+            description=self.get_message('description'))
         self.parser.add_argument(
             '--all',
             action="store_true",
@@ -213,10 +194,27 @@ class Client():
             help=(
                 "Do not display passing tests for better orientation in"
                 " graphs that contain a large amount of nodes.(Not implemented)"))
-        self.parser.add_argument("source_filename", help="ARF scan file")
+        self.parser.add_argument(
+            '-o',
+            '--output',
+            action="store",
+            default=None,
+            help=self.get_message('--output'))
+        self.parser.add_argument(
+            "source_filename",
+            help=self.get_message('source_filename'))
         self.parser.add_argument(
             "rule_id", help=(
                 "Rule ID to be visualized. A part from the full rule ID"
                 " a part of the ID or a regular expression can be used."
                 " If brackets are used in the regular expression "
                 "the regular expression must be quoted."))
+
+# Message text is defined in children of Client.
+    def get_message(self, parameter):
+        messages = {
+            'description': '',
+            '--output': '',
+            'source_filename': '',
+        }
+        return messages[parameter]

--- a/oval_graph/client.py
+++ b/oval_graph/client.py
@@ -111,34 +111,6 @@ class Client():
             x for x in self.xml_parser.notselected_rules if re.search(
                 self.rule_name, x['id_rule'])]
 
-    def create_dict_of_rule(self, rule_id):
-        converter = Converter(self.xml_parser.get_oval_tree(rule_id))
-        return converter.to_JsTree_dict()
-
-    def get_src(self, src):
-        _dir = os.path.dirname(os.path.realpath(__file__))
-        FIXTURE_DIR = os.path.join(_dir, src)
-        return str(FIXTURE_DIR)
-
-    def copy_interpreter(self, dst):
-        src = self.get_src('tree_html_interpreter')
-        os.mkdir(dst)
-        for item in os.listdir(src):
-            s = os.path.join(src, item)
-            d = os.path.join(dst, item)
-            if os.path.isdir(s):
-                shutil.copytree(s, d)
-            else:
-                shutil.copy2(s, d)
-
-    def open_web_browser(self, src):
-        if not self.off_webbrowser:
-            src = os.path.join(src, 'index.html')
-            try:
-                webbrowser.get('firefox').open_new_tab(src)
-            except BaseException:
-                webbrowser.open_new_tab(src)
-
     def search_rules_id(self):
         rules = self._get_wanted_rules()
         notselected_rules = self._get_wanted_not_selected_rules()
@@ -155,6 +127,34 @@ class Client():
             raise ValueError('err- 404 rule not found!')
         else:
             return rules
+
+    def open_web_browser(self, src):
+        if not self.off_webbrowser:
+            src = os.path.join(src, 'index.html')
+            try:
+                webbrowser.get('firefox').open_new_tab(src)
+            except BaseException:
+                webbrowser.open_new_tab(src)
+
+    def create_dict_of_rule(self, rule_id):
+        converter = Converter(self.xml_parser.get_oval_tree(rule_id))
+        return converter.to_JsTree_dict()
+
+    def copy_interpreter(self, dst):
+        src = self.get_src('tree_html_interpreter')
+        os.mkdir(dst)
+        for item in os.listdir(src):
+            s = os.path.join(src, item)
+            d = os.path.join(dst, item)
+            if os.path.isdir(s):
+                shutil.copytree(s, d)
+            else:
+                shutil.copy2(s, d)
+
+    def get_src(self, src):
+        _dir = os.path.dirname(os.path.realpath(__file__))
+        FIXTURE_DIR = os.path.join(_dir, src)
+        return str(FIXTURE_DIR)
 
     def save_dict(self, dict_, src):
         with open(os.path.join(src, 'data.js'), "w+") as data_file:

--- a/oval_graph/json_to_html.py
+++ b/oval_graph/json_to_html.py
@@ -27,24 +27,27 @@ class JsonToHtml(Client):
             raise NotImplementedError('Not implemented!')
         self.oval_tree = None
         self.off_webbrowser = self.arg.off_web_browser
+        self.json_data_file = self.get_json_data_file()
 
-    def load_json_to_oval_tree(self, rule):
+    def get_json_data_file(self):
         with open(self.source_filename, 'r') as f:
             try:
-                return restore_dict_to_tree(json.load(f)[rule])
+                return json.load(f)
             except Exception as error:
                 raise ValueError("err- Used file is not json or valid.")
+
+    def load_json_to_oval_tree(self, rule):
+        try:
+            return restore_dict_to_tree(self.json_data_file[rule])
+        except Exception as error:
+            raise ValueError("err- Data is not valid for oval tree.")
 
     def create_dict_of_oval_node(self, oval_node):
         converter = Converter(oval_node)
         return converter.to_JsTree_dict()
 
     def load_rule_names(self):
-        with open(self.source_filename, 'r') as f:
-            try:
-                return json.load(f).keys()
-            except Exception as error:
-                raise ValueError("err- Used file is not json or valid.")
+        return self.json_data_file.keys()
 
     def get_rules_id(self):
         out = []

--- a/oval_graph/json_to_html.py
+++ b/oval_graph/json_to_html.py
@@ -72,16 +72,17 @@ class JsonToHtml(Client):
                     self.source_filename, error))
 
     def prepare_parser(self):
-        self.parser = argparse.ArgumentParser(
-            description="Client for visualization of SCAP rule evaluation results")
+        super().prepare_parser()
         self.parser.add_argument(
             '--off-web-browser',
             action="store_true",
             default=False,
             help="It does not start the web browser.")
-        self.parser.add_argument(
-            '--all',
-            action="store_true",
-            default=False,
-            help="Process all matched rules.")
-        self.parser.add_argument("source_filename", help="ARF scan file")
+
+    def get_message(self, parameter):
+        messages = {
+            'description': 'Client for visualization of JSON created by command arf-to-json',
+            '--output': 'The directory where to save output directory with files.',
+            'source_filename': 'JSON file',
+        }
+        return messages[parameter]

--- a/oval_graph/json_to_html.py
+++ b/oval_graph/json_to_html.py
@@ -14,6 +14,7 @@ from .converter import Converter
 class JsonToHtml(Client):
     def __init__(self, args):
         self.parser = None
+        self.MESSAGES = self._get_message()
         self.arg = self.parse_arguments(args)
         self.remove_pass_tests = self.arg.remove_pass_tests
         self.source_filename = self.arg.source_filename
@@ -28,6 +29,14 @@ class JsonToHtml(Client):
         self.oval_tree = None
         self.off_webbrowser = self.arg.off_web_browser
         self.json_data_file = self.get_json_data_file()
+
+    def _get_message(self):
+        MESSAGES = {
+            'description': 'Client for visualization of JSON created by command arf-to-json',
+            '--output': 'The directory where to save output directory with files.',
+            'source_filename': 'JSON file',
+        }
+        return MESSAGES
 
     def get_json_data_file(self):
         with open(self.source_filename, 'r') as f:
@@ -95,11 +104,3 @@ class JsonToHtml(Client):
             action="store_true",
             default=False,
             help="It does not start the web browser.")
-
-    def get_message(self, parameter):
-        messages = {
-            'description': 'Client for visualization of JSON created by command arf-to-json',
-            '--output': 'The directory where to save output directory with files.',
-            'source_filename': 'JSON file',
-        }
-        return messages[parameter]

--- a/tests/any_test_help.py
+++ b/tests/any_test_help.py
@@ -1,5 +1,8 @@
 import os
 import json
+import sys
+import mock
+import pytest
 
 from oval_graph.oval_node import restore_dict_to_tree, OvalNode
 from oval_graph.converter import Converter
@@ -126,3 +129,99 @@ def compare_results_json(result):
         'test_data/referenc_result_data_json.json')
     assert result[list(result.keys())[
         0]] == referenc_result["xccdf_org.ssgproject.content_rule_package_abrt_removed"]
+
+
+def get_questions_not_selected(capsys, client):
+    out = client.get_questions()[0].choices
+    outResult = [
+        'xccdf_org.ssgproject.content_rule_package_abrt_removed',
+        'xccdf_org.ssgproject.content_rule_package_sendmail_removed']
+    assert out == outResult
+    captured = capsys.readouterr()
+# Problem with CI when si called function test_arf_to_hml.test_get_question_not_selected
+# other calls work with ==.
+    assert (('== The not selected rule IDs ==\n'
+             'xccdf_org.ssgproject.content_rule_package_nis_removed(Not selected)\n'
+             'xccdf_org.ssgproject.content_rule_package_ntpdate_removed(Not selected)\n'
+             'xccdf_org.ssgproject.content_rule_package_telnetd_removed(Not selected)\n'
+             'xccdf_org.ssgproject.content_rule_package_gdm_removed(Not selected)\n'
+             'xccdf_org.ssgproject.content_rule_package_setroubleshoot_removed(Not selected)\n'
+             'xccdf_org.ssgproject.content_rule_package_mcstrans_removed(Not selected)\n')
+            in captured.out)
+
+
+def get_questions_not_selected_and_show_fail_rules(capsys, client):
+    out = client.get_questions()[0].choices
+    outResult = ['xccdf_org.ssgproject.content_rule_package_abrt_removed']
+    assert out == outResult
+    captured = capsys.readouterr()
+    assert captured.out == (
+        '== The not selected rule IDs ==\n'
+        'xccdf_org.ssgproject.content_rule_package_nis_removed(Not selected)\n'
+        'xccdf_org.ssgproject.content_rule_package_ntpdate_removed(Not selected)\n'
+        'xccdf_org.ssgproject.content_rule_package_telnetd_removed(Not selected)\n'
+        'xccdf_org.ssgproject.content_rule_package_gdm_removed(Not selected)\n'
+        'xccdf_org.ssgproject.content_rule_package_setroubleshoot_removed(Not selected)\n'
+        'xccdf_org.ssgproject.content_rule_package_mcstrans_removed(Not selected)\n')
+
+
+def get_questions_with_option_show_fail_rules(client):
+    out = client.get_questions()[0].choices
+    rule1 = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
+    assert out[0] == rule1
+    with pytest.raises(Exception, match="list index out of range"):
+        assert out[2] is None
+
+
+def if_not_installed_inquirer_with_option_show_fail_rules(capsys, client):
+    with mock.patch.dict(sys.modules, {'inquirer': None}):
+        out = client.run_gui_and_return_answers()
+        assert out is None
+        captured = capsys.readouterr()
+        assert captured.out == (
+            '== The Rule IDs ==\n'
+            "'xccdf_org.ssgproject.content_rule_package_abrt_removed\\b'\n"
+            "You haven't got installed inquirer lib. Please copy id rule with you"
+            " want use and put it in command\n")
+
+
+def if_not_installed_inquirer_with_option_show_not_selected_rules(
+        capsys, client):
+    with mock.patch.dict(sys.modules, {'inquirer': None}):
+        out = client.run_gui_and_return_answers()
+        assert out is None
+        captured = capsys.readouterr()
+        assert captured.out == (
+            '== The Rule IDs ==\n'
+            "'xccdf_org.ssgproject.content_rule_package_abrt_removed\\b'\n"
+            "'xccdf_org.ssgproject.content_rule_package_sendmail_removed\\b'\n"
+            '== The not selected rule IDs ==\n'
+            'xccdf_org.ssgproject.content_rule_package_nis_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_ntpdate_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_telnetd_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_gdm_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_setroubleshoot_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_mcstrans_removed(Not selected)\n'
+            "You haven't got installed inquirer lib. Please copy id rule with you"
+            " want use and put it in command\n")
+
+
+def if_not_installed_inquirer_with_option_show_not_selected_rules_and_show_fail_rules(
+        capsys,
+        client):
+    with mock.patch.dict(sys.modules, {'inquirer': None}):
+        out = client.run_gui_and_return_answers()
+        assert out is None
+        captured = capsys.readouterr()
+        assert captured.out == (
+            '== The Rule IDs ==\n'
+            "'xccdf_org.ssgproject.content_rule_package_abrt_removed\\b'\n"
+            '== The not selected rule IDs ==\n'
+            'xccdf_org.ssgproject.content_rule_package_nis_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_ntpdate_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_telnetd_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_gdm_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_setroubleshoot_removed(Not selected)\n'
+            'xccdf_org.ssgproject.content_rule_package_mcstrans_removed(Not selected)\n'
+            "You haven't got installed inquirer lib. Please copy id rule with you"
+            " want use and put it in command\n")

--- a/tests/test_arf_to_hml.py
+++ b/tests/test_arf_to_hml.py
@@ -2,6 +2,8 @@ import pytest
 import tempfile
 import os
 import uuid
+import mock
+import sys
 
 from oval_graph.arf_to_html import ArfToHtml
 import tests.any_test_help
@@ -19,6 +21,26 @@ def get_client_arf_to_html_with_define_dest(src, rule):
          "--off-web-browser",
          tests.any_test_help.get_src(src),
          rule])
+
+
+def get_client_arf_to_html_with_option_show_fail_rules(src, rule):
+    return ArfToHtml(["--show-fail-rules",
+                      tests.any_test_help.get_src(src), rule])
+
+
+def get_client_arf_to_html_with_option_show_not_selected_rules(src, rule):
+    return ArfToHtml(["--show-not-selected-rules",
+                      tests.any_test_help.get_src(src),
+                      rule])
+
+
+def get_client_arf_to_html_with_option_show_not_selected_rules_and_show_fail_rules(
+        src,
+        rule):
+    return ArfToHtml(["--show-not-selected-rules",
+                      "--show-fail-rules",
+                      tests.any_test_help.get_src(src),
+                      rule])
 
 
 def try_expection_for_prepare_graph(src, rule, err):
@@ -57,3 +79,61 @@ def test_prepare_tree_and_save_in_defined_destination():
     rules = {'rules': [rule]}
     results_src = client.prepare_data(rules)
     tests.any_test_help.compare_results_js(results_src[0])
+
+
+def test_get_questions_not_selected(capsys):
+    src = 'test_data/ssg-fedora-ds-arf.xml'
+    regex = r'_package_\w+_removed'
+    client = get_client_arf_to_html_with_option_show_not_selected_rules(
+        src, regex)
+    tests.any_test_help.get_questions_not_selected(capsys, client)
+
+
+def test_get_questions_not_selected_and_show_fail_rules(capsys):
+    src = 'test_data/ssg-fedora-ds-arf.xml'
+    regex = r'_package_\w+_removed'
+    client = get_client_arf_to_html_with_option_show_not_selected_rules_and_show_fail_rules(
+        src, regex)
+    tests.any_test_help.get_questions_not_selected_and_show_fail_rules(
+        capsys, client)
+
+
+def test_get_questions_with_option_show_fail_rules():
+    src = 'test_data/ssg-fedora-ds-arf.xml'
+    regex = r'_package_\w+_removed'
+    client = get_client_arf_to_html_with_option_show_fail_rules(src, regex)
+    tests.any_test_help.get_questions_with_option_show_fail_rules(client)
+
+
+def test_if_not_installed_inquirer_with_option_show_fail_rules(capsys):
+    with mock.patch.dict(sys.modules, {'inquirer': None}):
+        src = 'test_data/ssg-fedora-ds-arf.xml'
+        regex = r'_package_\w+_removed'
+        client = get_client_arf_to_html_with_option_show_fail_rules(src, regex)
+        client.isatty = True
+        tests.any_test_help.if_not_installed_inquirer_with_option_show_fail_rules(
+            capsys, client)
+
+
+def test_if_not_installed_inquirer_with_option_show_not_selected_rules(capsys):
+    with mock.patch.dict(sys.modules, {'inquirer': None}):
+        src = 'test_data/ssg-fedora-ds-arf.xml'
+        regex = r'_package_\w+_removed'
+        client = get_client_arf_to_html_with_option_show_not_selected_rules(
+            src, regex)
+        client.isatty = True
+        tests.any_test_help.if_not_installed_inquirer_with_option_show_not_selected_rules(
+            capsys, client)
+
+
+def test_if_not_installed_inquirer_with_option_show_not_selected_rules_and_show_fail_rules(
+        capsys):
+    with mock.patch.dict(sys.modules, {'inquirer': None}):
+        src = 'test_data/ssg-fedora-ds-arf.xml'
+        regex = r'_package_\w+_removed'
+        client = get_client_arf_to_html_with_option_show_not_selected_rules_and_show_fail_rules(
+            src, regex)
+        client.isatty = True
+        (tests.any_test_help.
+         if_not_installed_inquirer_with_option_show_not_selected_rules_and_show_fail_rules(
+             capsys, client))

--- a/tests/test_arf_to_json.py
+++ b/tests/test_arf_to_json.py
@@ -3,6 +3,8 @@ import tempfile
 import os
 import uuid
 import json
+import mock
+import sys
 from datetime import datetime
 import time
 
@@ -19,6 +21,26 @@ def get_client_arf_to_json_with_define_dest(src, rule):
     return ArfToJson(["--output",
                       tests.any_test_help.get_src(os.path.join(tempfile.gettempdir(),
                                                                str(uuid.uuid4()) + ".json")),
+                      tests.any_test_help.get_src(src),
+                      rule])
+
+
+def get_client_arf_to_json_with_option_show_fail_rules(src, rule):
+    return ArfToJson(["--show-fail-rules",
+                      tests.any_test_help.get_src(src), rule])
+
+
+def get_client_arf_to_json_with_option_show_not_selected_rules(src, rule):
+    return ArfToJson(["--show-not-selected-rules",
+                      tests.any_test_help.get_src(src),
+                      rule])
+
+
+def get_client_arf_to_json_with_option_show_not_selected_rules_and_show_fail_rules(
+        src,
+        rule):
+    return ArfToJson(["--show-not-selected-rules",
+                      "--show-fail-rules",
                       tests.any_test_help.get_src(src),
                       rule])
 
@@ -150,3 +172,62 @@ def test_creation_json_two_selected_rules():
     assert referenc_result[
         "xccdf_org.ssgproject.content_rule_package_abrt_removed"] == data[rules_id[0]]
     assert rule1 in rules_id[1]
+
+
+def test_get_questions_not_selected(capsys):
+    src = 'test_data/ssg-fedora-ds-arf.xml'
+    regex = r'_package_\w+_removed'
+    client = get_client_arf_to_json_with_option_show_not_selected_rules(
+        src, regex)
+    tests.any_test_help.get_questions_not_selected(capsys, client)
+
+
+def test_get_questions_not_selected_and_show_fail_rules(capsys):
+    src = 'test_data/ssg-fedora-ds-arf.xml'
+    regex = r'_package_\w+_removed'
+    client = get_client_arf_to_json_with_option_show_not_selected_rules_and_show_fail_rules(
+        src, regex)
+    tests.any_test_help.get_questions_not_selected_and_show_fail_rules(
+        capsys, client)
+
+
+def test_get_questions_with_option_show_fail_rules():
+    src = 'test_data/ssg-fedora-ds-arf.xml'
+    regex = r'_package_\w+_removed'
+    client = get_client_arf_to_json_with_option_show_fail_rules(src, regex)
+    tests.any_test_help.get_questions_with_option_show_fail_rules(client)
+
+
+def test_if_not_installed_inquirer_with_option_show_fail_rules(capsys):
+    with mock.patch.dict(sys.modules, {'inquirer': None}):
+        src = 'test_data/ssg-fedora-ds-arf.xml'
+        regex = r'_package_\w+_removed'
+        client = get_client_arf_to_json_with_option_show_fail_rules(src, regex)
+        client.isatty = True
+        tests.any_test_help.if_not_installed_inquirer_with_option_show_fail_rules(
+            capsys, client)
+
+
+def test_if_not_installed_inquirer_with_option_show_not_selected_rules(
+        capsys):
+    with mock.patch.dict(sys.modules, {'inquirer': None}):
+        src = 'test_data/ssg-fedora-ds-arf.xml'
+        regex = r'_package_\w+_removed'
+        client = get_client_arf_to_json_with_option_show_not_selected_rules(
+            src, regex)
+        client.isatty = True
+        tests.any_test_help.if_not_installed_inquirer_with_option_show_not_selected_rules(
+            capsys, client)
+
+
+def test_if_not_installed_inquirer_with_option_show_not_selected_rules_and_show_fail_rules(
+        capsys):
+    with mock.patch.dict(sys.modules, {'inquirer': None}):
+        src = 'test_data/ssg-fedora-ds-arf.xml'
+        regex = r'_package_\w+_removed'
+        client = get_client_arf_to_json_with_option_show_not_selected_rules_and_show_fail_rules(
+            src, regex)
+        client.isatty = True
+        (tests.any_test_help.
+         if_not_installed_inquirer_with_option_show_not_selected_rules_and_show_fail_rules(
+             capsys, client))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -21,26 +21,6 @@ def get_client_on_web_browser(src, rule):
         [tests.any_test_help.get_src(src), rule])
 
 
-def get_client_with_option_show_fail_rules(src, rule):
-    return Client(["--show-fail-rules",
-                   tests.any_test_help.get_src(src), rule])
-
-
-def get_client_with_option_show_not_selected_rules(src, rule):
-    return Client(["--show-not-selected-rules",
-                   tests.any_test_help.get_src(src),
-                   rule])
-
-
-def get_client_with_option_show_not_selected_rules_and_show_fail_rules(
-        src,
-        rule):
-    return Client(["--show-not-selected-rules",
-                   "--show-fail-rules",
-                   tests.any_test_help.get_src(src),
-                   rule])
-
-
 def test_client():
     src = 'test_data/ssg-fedora-ds-arf.xml'
     rule = 'rule'
@@ -95,58 +75,6 @@ def test_get_questions():
     rule2 = 'xccdf_org.ssgproject.content_rule_package_sendmail_removed'
     assert out[0] == rule1
     assert out[1] == rule2
-
-
-def test_get_questions_not_selected(capsys):
-    src = 'test_data/ssg-fedora-ds-arf.xml'
-    regex = r'_package_\w+_removed'
-    client = get_client_with_option_show_not_selected_rules(src, regex)
-    out = client.get_questions()[0].choices
-    outResult = [
-        'xccdf_org.ssgproject.content_rule_package_abrt_removed',
-        'xccdf_org.ssgproject.content_rule_package_sendmail_removed']
-    assert out == outResult
-    captured = capsys.readouterr()
-    assert captured.out == (
-        '== The not selected rule IDs ==\n'
-        'xccdf_org.ssgproject.content_rule_package_nis_removed(Not selected)\n'
-        'xccdf_org.ssgproject.content_rule_package_ntpdate_removed(Not selected)\n'
-        'xccdf_org.ssgproject.content_rule_package_telnetd_removed(Not selected)\n'
-        'xccdf_org.ssgproject.content_rule_package_gdm_removed(Not selected)\n'
-        'xccdf_org.ssgproject.content_rule_package_setroubleshoot_removed(Not selected)\n'
-        'xccdf_org.ssgproject.content_rule_package_mcstrans_removed(Not selected)\n')
-
-
-def test_get_questions_not_selected_and_show_fail_rules(capsys):
-    src = 'test_data/ssg-fedora-ds-arf.xml'
-    regex = r'_package_\w+_removed'
-    client = get_client_with_option_show_not_selected_rules_and_show_fail_rules(
-        src, regex)
-    out = client.get_questions()[0].choices
-    outResult = ['xccdf_org.ssgproject.content_rule_package_abrt_removed']
-    assert out == outResult
-    assert len(out) == 1
-    captured = capsys.readouterr()
-    print(captured.out)
-    assert captured.out == (
-        '== The not selected rule IDs ==\n'
-        'xccdf_org.ssgproject.content_rule_package_nis_removed(Not selected)\n'
-        'xccdf_org.ssgproject.content_rule_package_ntpdate_removed(Not selected)\n'
-        'xccdf_org.ssgproject.content_rule_package_telnetd_removed(Not selected)\n'
-        'xccdf_org.ssgproject.content_rule_package_gdm_removed(Not selected)\n'
-        'xccdf_org.ssgproject.content_rule_package_setroubleshoot_removed(Not selected)\n'
-        'xccdf_org.ssgproject.content_rule_package_mcstrans_removed(Not selected)\n')
-
-
-def test_get_questions_with_option_show_fail_rules():
-    src = 'test_data/ssg-fedora-ds-arf.xml'
-    regex = r'_package_\w+_removed'
-    client = get_client_with_option_show_fail_rules(src, regex)
-    out = client.get_questions()[0].choices
-    rule1 = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
-    assert out[0] == rule1
-    with pytest.raises(Exception, match="list index out of range"):
-        assert out[2] is None
 
 
 def test_get_wanted_not_selected_rules():
@@ -210,71 +138,5 @@ def test_if_not_installed_inquirer(capsys):
             '== The Rule IDs ==\n'
             "'xccdf_org.ssgproject.content_rule_package_abrt_removed\\b'\n"
             "'xccdf_org.ssgproject.content_rule_package_sendmail_removed\\b'\n"
-            "You haven't got installed inquirer lib. Please copy id rule with you"
-            " want use and put it in command\n")
-
-
-def test_if_not_installed_inquirer_with_option_show_fail_rules(capsys):
-    with mock.patch.dict(sys.modules, {'inquirer': None}):
-        src = 'test_data/ssg-fedora-ds-arf.xml'
-        regex = r'_package_\w+_removed'
-        client = get_client_with_option_show_fail_rules(src, regex)
-        client.isatty = True
-        out = client.run_gui_and_return_answers()
-        assert out is None
-        captured = capsys.readouterr()
-        assert captured.out == (
-            '== The Rule IDs ==\n'
-            "'xccdf_org.ssgproject.content_rule_package_abrt_removed\\b'\n"
-            "You haven't got installed inquirer lib. Please copy id rule with you"
-            " want use and put it in command\n")
-
-
-def test_if_not_installed_inquirer_with_option_show_not_selected_rules(
-        capsys):
-    with mock.patch.dict(sys.modules, {'inquirer': None}):
-        src = 'test_data/ssg-fedora-ds-arf.xml'
-        regex = r'_package_\w+_removed'
-        client = get_client_with_option_show_not_selected_rules(src, regex)
-        client.isatty = True
-        out = client.run_gui_and_return_answers()
-        assert out is None
-        captured = capsys.readouterr()
-        assert captured.out == (
-            '== The Rule IDs ==\n'
-            "'xccdf_org.ssgproject.content_rule_package_abrt_removed\\b'\n"
-            "'xccdf_org.ssgproject.content_rule_package_sendmail_removed\\b'\n"
-            '== The not selected rule IDs ==\n'
-            'xccdf_org.ssgproject.content_rule_package_nis_removed(Not selected)\n'
-            'xccdf_org.ssgproject.content_rule_package_ntpdate_removed(Not selected)\n'
-            'xccdf_org.ssgproject.content_rule_package_telnetd_removed(Not selected)\n'
-            'xccdf_org.ssgproject.content_rule_package_gdm_removed(Not selected)\n'
-            'xccdf_org.ssgproject.content_rule_package_setroubleshoot_removed(Not selected)\n'
-            'xccdf_org.ssgproject.content_rule_package_mcstrans_removed(Not selected)\n'
-            "You haven't got installed inquirer lib. Please copy id rule with you"
-            " want use and put it in command\n")
-
-
-def test_if_not_installed_inquirer_with_option_show_not_selected_rules_and_show_fail_rules(
-        capsys):
-    with mock.patch.dict(sys.modules, {'inquirer': None}):
-        src = 'test_data/ssg-fedora-ds-arf.xml'
-        regex = r'_package_\w+_removed'
-        client = get_client_with_option_show_not_selected_rules_and_show_fail_rules(
-            src, regex)
-        client.isatty = True
-        out = client.run_gui_and_return_answers()
-        assert out is None
-        captured = capsys.readouterr()
-        assert captured.out == (
-            '== The Rule IDs ==\n'
-            "'xccdf_org.ssgproject.content_rule_package_abrt_removed\\b'\n"
-            '== The not selected rule IDs ==\n'
-            'xccdf_org.ssgproject.content_rule_package_nis_removed(Not selected)\n'
-            'xccdf_org.ssgproject.content_rule_package_ntpdate_removed(Not selected)\n'
-            'xccdf_org.ssgproject.content_rule_package_telnetd_removed(Not selected)\n'
-            'xccdf_org.ssgproject.content_rule_package_gdm_removed(Not selected)\n'
-            'xccdf_org.ssgproject.content_rule_package_setroubleshoot_removed(Not selected)\n'
-            'xccdf_org.ssgproject.content_rule_package_mcstrans_removed(Not selected)\n'
             "You haven't got installed inquirer lib. Please copy id rule with you"
             " want use and put it in command\n")

--- a/tests/test_data/bad_result_data_json.json
+++ b/tests/test_data/bad_result_data_json.json
@@ -1,0 +1,23 @@
+{
+    "xccdf_org.ssgproject.content_rule_package_abrt_removed": {
+        "node_id": "xccdf_org.ssgproject.content_rule_package_abrt_removed",
+        "negation": false,
+        "comment": "Package abrt Removed",
+        "child": [
+            {
+                "node_id": "oval:ssg-package_abrt_removed:def:1",
+                "value": "and",
+                "negation": false,
+                "comment": null,
+                "child": [
+                    {
+                        "node_id": "oval:ssg-test_package_abrt_removed:tst:1",
+                        "type": "value",
+                        "comment": "package abrt is removed",
+                        "child": null
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/test_json_to_html.py
+++ b/tests/test_json_to_html.py
@@ -7,23 +7,48 @@ from oval_graph.json_to_html import JsonToHtml
 import tests.any_test_help
 
 
-def get_client_json_to_html(src):
+def get_client_json_to_html(src, rule):
     return JsonToHtml(
-        ["--off-web-browser", tests.any_test_help.get_src(src)])
+        ["--off-web-browser",
+         tests.any_test_help.get_src(src),
+         rule,
+         ])
 
 
-def get_client_json_to_html_with_define_dest(src):
+def get_client_json_to_html_with_define_dest(src, rule):
     return JsonToHtml(
         ["--output", tests.any_test_help.get_src(
             os.path.join(tempfile.gettempdir(), str(uuid.uuid4()))),
          "--off-web-browser",
-         tests.any_test_help.get_src(src)])
+         tests.any_test_help.get_src(src),
+         rule,
+         ])
+
+
+def try_expection_for_prepare_graph(src, rule, err):
+    rules = {'rules': [rule]}
+    with pytest.raises(Exception, match=err):
+        client = get_client_json_to_html(src, rule)
+        assert client.prepare_data(rules)
+
+
+def test_prepare_graph_with_non_existent_rule():
+    src = 'test_data/referenc_result_data_tree.js'
+    rule = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
+    try_expection_for_prepare_graph(src, rule, 'json or valid')
+
+
+def test_prepare_graph_with_bat_data():
+    src = 'test_data/bad_result_data_json.json'
+    rule = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
+    try_expection_for_prepare_graph(src, rule, 'valid for oval tree')
 
 
 @pytest.mark.usefixtures("remove_generated_reports_in_root")
 def test_prepare_tree():
     src = 'test_data/referenc_result_data_json.json'
-    client = get_client_json_to_html(src)
+    rule = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
+    client = get_client_json_to_html(src, rule)
     results_src = client.prepare_data({'rules': [
         rule['id_rule'] for rule in client.search_rules_id()]})
     tests.any_test_help.compare_results_js(results_src[0])
@@ -31,7 +56,8 @@ def test_prepare_tree():
 
 def test_prepare_tree_and_save_in_defined_destination():
     src = 'test_data/referenc_result_data_json.json'
-    client = get_client_json_to_html_with_define_dest(src)
+    rule = 'xccdf_org.ssgproject.content_rule_package_abrt_removed'
+    client = get_client_json_to_html_with_define_dest(src, rule)
     results_src = client.prepare_data({'rules': [
         rule['id_rule'] for rule in client.search_rules_id()]})
     tests.any_test_help.compare_results_js(results_src[0])


### PR DESCRIPTION
These PR contains:
- A new parameter `rule_name` in command `json-to-graph`. That can be used to search a rule stored in a json file.
- rework the json-to-graph class
- rework arg parser in Client class