### PR TITLE
Labels for OVAL tests and OVAL definitions

### DIFF
--- a/oval_graph/converter.py
+++ b/oval_graph/converter.py
@@ -15,6 +15,11 @@ class Converter():
             "notappl": "text-dark"
         }
 
+        self.BOOTSTRAP_COLOR_TO_LABEL_COLOR = {
+            "text-success": "label-success",
+            "text-danger": "label-danger",
+            "text-dark": "label-default"
+        }
         self.VALUE_TO_ICON = {
             "true": "glyphicon glyphicon-ok text-success",
             "false": "glyphicon glyphicon-remove text-danger",
@@ -41,18 +46,26 @@ class Converter():
             return str(self.tree.comment)
         return ""
 
+    def get_tag(self):
+        if self.tree.tag is not None:
+            return str(self.tree.tag)
+        return ""
+
     def to_JsTree_dict(self):
         icons = self._get_node_icon()
         label = self._get_label()
-        out = {
-            'text': (str(label['negation'] if label['negation'] else "") +
-                     ' <strong><span class="' + icons['color'] + '">' +
-                     label['str'] + '</span></strong>' +
-                     ' <i>' + self.get_comment() + '</i>'
-                     ),
-            "icon": icons['icon'],
-            "state": {
-                "opened": True}}
+        out = {'text':
+               '{negation} <strong><span class="{icon}">{label}</span></strong>'
+               ' <span class="label {color_tag}">{tag}</span> <i>{comment}</i>'
+               .format(negation=str(
+                   label['negation'] if label['negation'] else ""),
+                   icon=icons['color'],
+                   label=label['str'],
+                   color_tag=self.BOOTSTRAP_COLOR_TO_LABEL_COLOR[icons['color']],
+                   tag=self.get_tag(),
+                   comment=self.get_comment()),
+               "icon": icons['icon'],
+               "state": {"opened": True}}
         if self.tree.children:
             out['children'] = [Converter(child).to_JsTree_dict()
                                for child in self.tree.children]

--- a/oval_graph/oval_node.py
+++ b/oval_graph/oval_node.py
@@ -22,6 +22,7 @@ class OvalNode():
         input_value (str): value of node
         input_negation (bool): value indicating whether the node is negated or not
         comment (str): text about node
+        tag (str): tag specifies if the node represents OVAL test, OVAL definition or XCCDF rule
         children ([OvalNode]): array of children of node
 
     Attributes:
@@ -39,6 +40,7 @@ class OvalNode():
             input_value,
             input_negation,
             comment,
+            tag,
             children=None
     ):
         self.comment = comment
@@ -48,6 +50,7 @@ class OvalNode():
         self.value = self.validate_type_and_value(input_value)
         self.children = []
         self.validate_children(children)
+        self.tag = tag
         if children:
             for child in children:
                 self.add_child(child)
@@ -158,6 +161,7 @@ class OvalNode():
                 'value': self.value,
                 'negation': self.negation,
                 'comment': self.comment,
+                'tag': self.tag,
                 'child': None
             }
         return {
@@ -166,6 +170,7 @@ class OvalNode():
             'value': self.value,
             'negation': self.negation,
             'comment': self.comment,
+            'tag': self.tag,
             'child': [child.save_tree_to_dict() for child in self.children]
         }
 
@@ -194,6 +199,7 @@ def restore_dict_to_tree(dict_of_tree):
             dict_of_tree["type"],
             dict_of_tree["value"],
             dict_of_tree["negation"],
+            dict_of_tree["tag"],
             dict_of_tree['comment'])
     return OvalNode(
         dict_of_tree["node_id"],
@@ -201,4 +207,5 @@ def restore_dict_to_tree(dict_of_tree):
         dict_of_tree["value"],
         dict_of_tree["negation"],
         dict_of_tree['comment'],
+        dict_of_tree["tag"],
         [restore_dict_to_tree(i) for i in dict_of_tree["child"]])

--- a/oval_graph/xml_parser.py
+++ b/oval_graph/xml_parser.py
@@ -109,6 +109,7 @@ class XmlParser():
                         child['value'],
                         child['negate'],
                         child['comment'],
+                        child['tag']
                     ))
 
         if 'id' in dict_of_definition:
@@ -121,6 +122,7 @@ class XmlParser():
                 dict_of_definition['operator'],
                 dict_of_definition['negate'],
                 dict_of_definition['comment'],
+                dict_of_definition['tag'],
                 children,
             )
 
@@ -146,6 +148,7 @@ class XmlParser():
             'and',
             False,
             dict_of_definition['comment'],
+            "Rule",
             [self._xml_dict_to_node(dict_of_definition)],
         )
 
@@ -162,7 +165,7 @@ class XmlParser():
             if 'negate' in tree:
                 negate_status = self._str_to_bool(tree.get('negate'))
             graph['negate'] = negate_status
-            graph['node'].append(self._build_node(tree))
+            graph['node'].append(self._build_node(tree, "Definition"))
         return graph
 
     def _str_to_bool(self, s):
@@ -173,7 +176,7 @@ class XmlParser():
         else:
             raise ValueError('err- negation is not bool')
 
-    def _build_node(self, tree):
+    def _build_node(self, tree, tag):
         negate_status = False
         if tree.get('negate') is not None:
             negate_status = self._str_to_bool(tree.get('negate'))
@@ -183,11 +186,12 @@ class XmlParser():
             negate=negate_status,
             result=tree.get('result'),
             comment=None,
+            tag=tag,
             node=[],
         )
         for child in tree:
             if child.get('operator') is not None:
-                node['node'].append(self._build_node(child))
+                node['node'].append(self._build_node(child, "Criteria"))
             else:
                 negate_status = False
                 if child.get('negate') is not None:
@@ -200,6 +204,7 @@ class XmlParser():
                             result=child.get('result'),
                             negate=negate_status,
                             comment=None,
+                            tag="Extend definition",
                         ))
                 else:
                     node['node'].append(
@@ -208,6 +213,7 @@ class XmlParser():
                             value=child.get('result'),
                             negate=negate_status,
                             comment=None,
+                            tag="Test",
                         ))
         return node
 
@@ -231,6 +237,7 @@ class XmlParser():
             negate=value['negate'],
             result=value['result'],
             comment=value['comment'],
+            tag=value['tag'],
             node=[],
         )
         for child in value['node']:
@@ -243,6 +250,7 @@ class XmlParser():
                         child['extend_definition'],
                         child['negate'],
                         child['comment'],
+                        child['tag'],
                     ))
             elif 'value_id' in child:
                 out['node'].append(child)
@@ -250,11 +258,12 @@ class XmlParser():
                 raise ValueError('error - unknown child')
         return out
 
-    def _find_definition_by_id(self, scan, id, negate_status, comment):
+    def _find_definition_by_id(self, scan, id, negate_status, comment, tag):
         for definition in scan['definitions']:
             if definition['id'] == id:
                 definition['node'][0]['negate'] = negate_status
                 definition['node'][0]['comment'] = comment
+                definition['node'][0]['tag'] = tag
                 return self._operator_as_child(definition['node'][0], scan)
 
     def create_dict_form_criteria(self, criteria, description):

--- a/oval_graph/xml_parser.py
+++ b/oval_graph/xml_parser.py
@@ -257,16 +257,16 @@ class XmlParser():
                 definition['node'][0]['comment'] = comment
                 return self._operator_as_child(definition['node'][0], scan)
 
-    def create_dict_form_criteria(self, criteria):
+    def create_dict_form_criteria(self, criteria, description):
         comments = dict(
             operator='AND' if criteria.get('operator') is None else criteria.get('operator'),
-            comment=criteria.get('comment'),
+            comment=description if criteria.get('comment') is None else criteria.get('comment'),
             node=[],
         )
         for criterion in criteria:
             if criterion.get('operator'):
                 comments['node'].append(
-                    self.create_dict_form_criteria(criterion))
+                    self.create_dict_form_criteria(criterion, None))
             else:
                 if criterion.get('definition_ref'):
                     comments['node'].append(
@@ -294,10 +294,12 @@ class XmlParser():
                 id=definition.get('id'), comment=None, node=[])
             title = definition.find(
                 './/oval-definitions:metadata/oval-definitions:title', ns)
+            description = definition.find(
+                './/oval-definitions:metadata/oval-definitions:description', ns)
             comment_definition['comment'] = title.text
             criteria = definition.find('.//oval-definitions:criteria', ns)
             comment_definition['node'].append(
-                self.create_dict_form_criteria(criteria))
+                self.create_dict_form_criteria(criteria, description.text))
             definitions.append(comment_definition)
         return definitions
 

--- a/tests/any_test_help.py
+++ b/tests/any_test_help.py
@@ -57,12 +57,12 @@ def any_test_create_node_dict_for_JsTree(Tree, json_src):
 
 
 def get_simple_tree():
-    return OvalNode(1, 'operator', 'and', False, None, [
-        OvalNode(2, 'value', "true", False, None),
-        OvalNode(3, 'value', "false", False, None),
-        OvalNode(4, 'operator', 'or', False, None, [
-            OvalNode(5, 'value', "false", False, None),
-            OvalNode(6, 'value', "true", False, None)
+    return OvalNode(1, 'operator', 'and', False, None, None, [
+        OvalNode(2, 'value', "true", False, None, None),
+        OvalNode(3, 'value', "false", False, None, None),
+        OvalNode(4, 'operator', 'or', False, None, None, [
+            OvalNode(5, 'value', "false", False, None, None),
+            OvalNode(6, 'value', "true", False, None, None)
         ]
         )
     ]

--- a/tests/test_JsTree.py
+++ b/tests/test_JsTree.py
@@ -11,8 +11,8 @@ def test_create_node_dict_for_JsTree_0():
 def test_create_node_dict_for_JsTree_1():
     src = 'test_JsTree_data/JsTree_data_1.json'
 
-    Tree = OvalNode(1, 'operator', 'and', False, None, [
-        OvalNode(2, 'value', "true", False, None)
+    Tree = OvalNode(1, 'operator', 'and', False, None, None, [
+        OvalNode(2, 'value', "true", False, None, None)
     ]
     )
 
@@ -22,8 +22,8 @@ def test_create_node_dict_for_JsTree_1():
 def test_create_node_dict_for_JsTree_2():
     src = 'test_JsTree_data/JsTree_data_2.json'
 
-    Tree = OvalNode(1, 'operator', 'and', False, None, [
-        OvalNode(2, 'value', "noteval", False, None)
+    Tree = OvalNode(1, 'operator', 'and', False, None, None, [
+        OvalNode(2, 'value', "noteval", False, None, None)
     ]
     )
 
@@ -33,7 +33,7 @@ def test_create_node_dict_for_JsTree_2():
 def test_create_node_dict_for_JsTree_3():
     src = 'test_JsTree_data/JsTree_data_3.json'
 
-    Tree = OvalNode(1, 'value', 'false', False, None)
+    Tree = OvalNode(1, 'value', 'false', False, None, None)
 
     tests.any_test_help.any_test_create_node_dict_for_JsTree(Tree, src)
 
@@ -41,7 +41,7 @@ def test_create_node_dict_for_JsTree_3():
 def test_create_node_dict_for_JsTree_4():
     src = 'test_JsTree_data/JsTree_data_4.json'
 
-    Tree = OvalNode(1, 'value', 'true', False, None)
+    Tree = OvalNode(1, 'value', 'true', False, None, None)
 
     tests.any_test_help.any_test_create_node_dict_for_JsTree(Tree, src)
 
@@ -49,7 +49,7 @@ def test_create_node_dict_for_JsTree_4():
 def test_create_node_dict_for_JsTree_5():
     src = 'test_JsTree_data/JsTree_data_5.json'
 
-    Tree = OvalNode(1, 'value', 'error', False, None)
+    Tree = OvalNode(1, 'value', 'error', False, None, None)
 
     tests.any_test_help.any_test_create_node_dict_for_JsTree(Tree, src)
 
@@ -57,8 +57,8 @@ def test_create_node_dict_for_JsTree_5():
 def test_create_node_with_negation_dict_for_JsTree():
     src = 'test_JsTree_data/JsTree_data_negated_0.json'
 
-    Tree = OvalNode(1, 'operator', 'and', True, None, [
-        OvalNode(2, 'value', "false", False, None)
+    Tree = OvalNode(1, 'operator', 'and', True, None, None, [
+        OvalNode(2, 'value', "false", False, None, None)
     ]
     )
 
@@ -68,8 +68,8 @@ def test_create_node_with_negation_dict_for_JsTree():
 def test_create_node_with_negation_dict_for_JsTree1():
     src = 'test_JsTree_data/JsTree_data_negated_1.json'
 
-    Tree = OvalNode(1, 'operator', 'and', True, None, [
-        OvalNode(2, 'value', "true", False, None)
+    Tree = OvalNode(1, 'operator', 'and', True, None, None, [
+        OvalNode(2, 'value', "true", False, None, None)
     ]
     )
 
@@ -79,8 +79,8 @@ def test_create_node_with_negation_dict_for_JsTree1():
 def test_create_node_with_negation_dict_for_JsTree2():
     src = 'test_JsTree_data/JsTree_data_negated_2.json'
 
-    Tree = OvalNode(1, 'operator', 'and', False, None, [
-        OvalNode(2, 'value', "true", True, None)
+    Tree = OvalNode(1, 'operator', 'and', False, None, None, [
+        OvalNode(2, 'value', "true", True, None, None)
     ]
     )
 
@@ -91,8 +91,8 @@ def test_create_node_with_negation_dict_for_JsTree2():
 def test_create_node_with_negation_dict_for_JsTree3():
     src = 'test_JsTree_data/JsTree_data_negated_3.json'
 
-    Tree = OvalNode(1, 'operator', 'and', False, None, [
-        OvalNode(2, 'value', "false", True, None)
+    Tree = OvalNode(1, 'operator', 'and', False,  None, None, [
+        OvalNode(2, 'value', "false", True, None, None)
     ]
     )
 

--- a/tests/test_JsTree_data/JsTree_data_0.json
+++ b/tests/test_JsTree_data/JsTree_data_0.json
@@ -1,40 +1,40 @@
 {
-    "text": " <strong><span class=\"text-danger\">AND</span></strong> <i></i>",
+    "text": " <strong><span class=\"text-danger\">AND</span></strong> <span class=\"label label-danger\"></span> <i></i>",
     "icon": "glyphicon glyphicon-remove text-danger",
     "state": {
         "opened": true
     },
     "children": [
         {
-            "text": " <strong><span class=\"text-success\">2</span></strong> <i></i>",
+            "text": " <strong><span class=\"text-success\">2</span></strong> <span class=\"label label-success\"></span> <i></i>",
             "icon": "glyphicon glyphicon-ok text-success",
             "state": {
                 "opened": true
             }
         },
         {
-            "text": " <strong><span class=\"text-danger\">3</span></strong> <i></i>",
+            "text": " <strong><span class=\"text-danger\">3</span></strong> <span class=\"label label-danger\"></span> <i></i>",
             "icon": "glyphicon glyphicon-remove text-danger",
             "state": {
                 "opened": true
             }
         },
         {
-            "text": " <strong><span class=\"text-success\">OR</span></strong> <i></i>",
+            "text": " <strong><span class=\"text-success\">OR</span></strong> <span class=\"label label-success\"></span> <i></i>",
             "icon": "glyphicon glyphicon-ok text-success",
             "state": {
                 "opened": true
             },
             "children": [
                 {
-                    "text": " <strong><span class=\"text-danger\">5</span></strong> <i></i>",
+                    "text": " <strong><span class=\"text-danger\">5</span></strong> <span class=\"label label-danger\"></span> <i></i>",
                     "icon": "glyphicon glyphicon-remove text-danger",
                     "state": {
                         "opened": true
                     }
                 },
                 {
-                    "text": " <strong><span class=\"text-success\">6</span></strong> <i></i>",
+                    "text": " <strong><span class=\"text-success\">6</span></strong> <span class=\"label label-success\"></span> <i></i>",
                     "icon": "glyphicon glyphicon-ok text-success",
                     "state": {
                         "opened": true

--- a/tests/test_JsTree_data/JsTree_data_1.json
+++ b/tests/test_JsTree_data/JsTree_data_1.json
@@ -1,12 +1,12 @@
 {
-    "text": " <strong><span class=\"text-success\">AND</span></strong> <i></i>",
+    "text": " <strong><span class=\"text-success\">AND</span></strong> <span class=\"label label-success\"></span> <i></i>",
     "icon": "glyphicon glyphicon-ok text-success",
     "state": {
         "opened": true
     },
     "children": [
         {
-            "text": " <strong><span class=\"text-success\">2</span></strong> <i></i>",
+            "text": " <strong><span class=\"text-success\">2</span></strong> <span class=\"label label-success\"></span> <i></i>",
             "icon": "glyphicon glyphicon-ok text-success",
             "state": {
                 "opened": true

--- a/tests/test_JsTree_data/JsTree_data_2.json
+++ b/tests/test_JsTree_data/JsTree_data_2.json
@@ -1,12 +1,12 @@
 {
-    "text": " <strong><span class=\"text-dark\">AND</span></strong> <i></i>",
+    "text": " <strong><span class=\"text-dark\">AND</span></strong> <span class=\"label label-default\"></span> <i></i>",
     "icon": "glyphicon glyphicon-question-sign text-dark",
     "state": {
         "opened": true
     },
     "children": [
         {
-            "text": " <strong><span class=\"text-dark\">2</span></strong> <i></i>",
+            "text": " <strong><span class=\"text-dark\">2</span></strong> <span class=\"label label-default\"></span> <i></i>",
             "icon": "glyphicon glyphicon-question-sign text-dark",
             "state": {
                 "opened": true

--- a/tests/test_JsTree_data/JsTree_data_3.json
+++ b/tests/test_JsTree_data/JsTree_data_3.json
@@ -1,5 +1,5 @@
 {
-    "text": " <strong><span class=\"text-danger\">1</span></strong> <i></i>",
+    "text": " <strong><span class=\"text-danger\">1</span></strong> <span class=\"label label-danger\"></span> <i></i>",
     "icon": "glyphicon glyphicon-remove text-danger",
     "state": {
         "opened": true

--- a/tests/test_JsTree_data/JsTree_data_4.json
+++ b/tests/test_JsTree_data/JsTree_data_4.json
@@ -1,5 +1,5 @@
 {
-    "text": " <strong><span class=\"text-success\">1</span></strong> <i></i>",
+    "text": " <strong><span class=\"text-success\">1</span></strong> <span class=\"label label-success\"></span> <i></i>",
     "icon": "glyphicon glyphicon-ok text-success",
     "state": {
         "opened": true

--- a/tests/test_JsTree_data/JsTree_data_5.json
+++ b/tests/test_JsTree_data/JsTree_data_5.json
@@ -1,5 +1,5 @@
 {
-    "text": " <strong><span class=\"text-dark\">1</span></strong> <i></i>",
+    "text": " <strong><span class=\"text-dark\">1</span></strong> <span class=\"label label-default\"></span> <i></i>",
     "icon": "glyphicon glyphicon-question-sign text-dark",
     "state": {
         "opened": true

--- a/tests/test_JsTree_data/JsTree_data_negated_0.json
+++ b/tests/test_JsTree_data/JsTree_data_negated_0.json
@@ -1,12 +1,12 @@
 {
-    "text": "<strong><span class=\"text-success\">NOT</strong></span> <strong><span class=\"text-danger\">AND</span></strong> <i></i>",
+    "text": "<strong><span class=\"text-success\">NOT</strong></span> <strong><span class=\"text-danger\">AND</span></strong> <span class=\"label label-danger\"></span> <i></i>",
     "icon": "glyphicon glyphicon-ok text-success",
     "state": {
         "opened": true
     },
     "children": [
         {
-            "text": " <strong><span class=\"text-danger\">2</span></strong> <i></i>",
+            "text": " <strong><span class=\"text-danger\">2</span></strong> <span class=\"label label-danger\"></span> <i></i>",
             "icon": "glyphicon glyphicon-remove text-danger",
             "state": {
                 "opened": true

--- a/tests/test_JsTree_data/JsTree_data_negated_1.json
+++ b/tests/test_JsTree_data/JsTree_data_negated_1.json
@@ -1,12 +1,12 @@
 {
-    "text": "<strong><span class=\"text-danger\">NOT</strong></span> <strong><span class=\"text-success\">AND</span></strong> <i></i>",
+    "text": "<strong><span class=\"text-danger\">NOT</strong></span> <strong><span class=\"text-success\">AND</span></strong> <span class=\"label label-success\"></span> <i></i>",
     "icon": "glyphicon glyphicon-remove text-danger",
     "state": {
         "opened": true
     },
     "children": [
         {
-            "text": " <strong><span class=\"text-success\">2</span></strong> <i></i>",
+            "text": " <strong><span class=\"text-success\">2</span></strong> <span class=\"label label-success\"></span> <i></i>",
             "icon": "glyphicon glyphicon-ok text-success",
             "state": {
                 "opened": true

--- a/tests/test_JsTree_data/JsTree_data_negated_2.json
+++ b/tests/test_JsTree_data/JsTree_data_negated_2.json
@@ -1,5 +1,5 @@
 {
-    "text": "<strong><span class=\"text-success\">NOT</strong></span> <strong><span class=\"text-danger\">2</span></strong> <i></i>",
+    "text": "<strong><span class=\"text-success\">NOT</strong></span> <strong><span class=\"text-danger\">2</span></strong> <span class=\"label label-danger\"></span> <i></i>",
     "icon": "glyphicon glyphicon-ok text-success",
     "state": {
         "opened": true

--- a/tests/test_JsTree_data/JsTree_data_negated_3.json
+++ b/tests/test_JsTree_data/JsTree_data_negated_3.json
@@ -1,5 +1,5 @@
 {
-    "text": "<strong><span class=\"text-danger\">NOT</strong></span> <strong><span class=\"text-success\">2</span></strong> <i></i>",
+    "text": "<strong><span class=\"text-danger\">NOT</strong></span> <strong><span class=\"text-success\">2</span></strong> <span class=\"label label-success\"></span> <i></i>",
     "icon": "glyphicon glyphicon-remove text-danger",
     "state": {
         "opened": true

--- a/tests/test_arf_to_json.py
+++ b/tests/test_arf_to_json.py
@@ -51,7 +51,6 @@ def test_prepare_json(capsys):
     results_src = client.prepare_data(rules)
     assert not results_src
     captured = capsys.readouterr()
-    print(repr(captured.out))
     assert captured.out == (
         '{\n'
         '    "graph-of-xccdf_org.ssgproject.content_rule_package_abrt_removed' +
@@ -62,6 +61,7 @@ def test_prepare_json(capsys):
         '        "value": "and",\n'
         '        "negation": false,\n'
         '        "comment": "Package abrt Removed",\n'
+        '        "tag": "Rule",\n'
         '        "child": [\n'
         '            {\n'
         '                "node_id": "oval:ssg-package_abrt_removed:def:1",\n'
@@ -69,6 +69,7 @@ def test_prepare_json(capsys):
         '                "value": "and",\n'
         '                "negation": false,\n'
         '                "comment": "The RPM package abrt should be removed.",\n'
+        '                "tag": "Definition",\n'
         '                "child": [\n'
         '                    {\n'
         '                        "node_id": "oval:ssg-test_package_abrt_removed:tst:1",\n'
@@ -76,6 +77,7 @@ def test_prepare_json(capsys):
         '                        "value": "false",\n'
         '                        "negation": false,\n'
         '                        "comment": "package abrt is removed",\n'
+        '                        "tag": "Test",\n'
         '                        "child": null\n'
         '                    }\n'
         '                ]\n'

--- a/tests/test_arf_to_json.py
+++ b/tests/test_arf_to_json.py
@@ -68,7 +68,7 @@ def test_prepare_json(capsys):
         '                "type": "operator",\n'
         '                "value": "and",\n'
         '                "negation": false,\n'
-        '                "comment": null,\n'
+        '                "comment": "The RPM package abrt should be removed.",\n'
         '                "child": [\n'
         '                    {\n'
         '                        "node_id": "oval:ssg-test_package_abrt_removed:tst:1",\n'

--- a/tests/test_data/JsTree_json0.json
+++ b/tests/test_data/JsTree_json0.json
@@ -1,68 +1,68 @@
 {
-    "text": " <strong><span class=\"text-danger\">rule_accounts_passwords_pam_faillock_deny</span></strong> <i>Lock out account after failed login attempts</i>",
+    "text": " <strong><span class=\"text-danger\">rule_accounts_passwords_pam_faillock_deny</span></strong> <span class=\"label label-danger\">Rule</span> <i>Lock out account after failed login attempts</i>",
     "icon": "glyphicon glyphicon-remove text-danger",
     "state": {
         "opened": true
     },
     "children": [
         {
-            "text": " <strong><span class=\"text-danger\">AND</span></strong> <i>Checks common to both scenarios</i>",
+            "text": " <strong><span class=\"text-danger\">AND</span></strong> <span class=\"label label-danger\">Definition</span> <i>Checks common to both scenarios</i>",
             "icon": "glyphicon glyphicon-remove text-danger",
             "state": {
                 "opened": true
             },
             "children": [
                 {
-                    "text": " <strong><span class=\"text-danger\">accounts_passwords_pam_faillock_preauth_silent_system-auth</span></strong> <i>pam_faillock.so preauth silent set in system-auth</i>",
+                    "text": " <strong><span class=\"text-danger\">accounts_passwords_pam_faillock_preauth_silent_system-auth</span></strong> <span class=\"label label-danger\">Test</span> <i>pam_faillock.so preauth silent set in system-auth</i>",
                     "icon": "glyphicon glyphicon-remove text-danger",
                     "state": {
                         "opened": true
                     }
                 },
                 {
-                    "text": " <strong><span class=\"text-danger\">accounts_passwords_pam_faillock_account_phase_system-auth</span></strong> <i>pam_faillock.so set in account phase of system-auth</i>",
+                    "text": " <strong><span class=\"text-danger\">accounts_passwords_pam_faillock_account_phase_system-auth</span></strong> <span class=\"label label-danger\">Test</span> <i>pam_faillock.so set in account phase of system-auth</i>",
                     "icon": "glyphicon glyphicon-remove text-danger",
                     "state": {
                         "opened": true
                     }
                 },
                 {
-                    "text": " <strong><span class=\"text-danger\">accounts_passwords_pam_faillock_preauth_silent_password-auth</span></strong> <i>pam_faillock.so preauth silent set in password-auth</i>",
+                    "text": " <strong><span class=\"text-danger\">accounts_passwords_pam_faillock_preauth_silent_password-auth</span></strong> <span class=\"label label-danger\">Test</span> <i>pam_faillock.so preauth silent set in password-auth</i>",
                     "icon": "glyphicon glyphicon-remove text-danger",
                     "state": {
                         "opened": true
                     }
                 },
                 {
-                    "text": " <strong><span class=\"text-danger\">accounts_passwords_pam_faillock_account_phase_password-auth</span></strong> <i>pam_faillock.so set in account phase of password-auth</i>",
+                    "text": " <strong><span class=\"text-danger\">accounts_passwords_pam_faillock_account_phase_password-auth</span></strong> <span class=\"label label-danger\">Test</span> <i>pam_faillock.so set in account phase of password-auth</i>",
                     "icon": "glyphicon glyphicon-remove text-danger",
                     "state": {
                         "opened": true
                     }
                 },
                 {
-                    "text": " <strong><span class=\"text-danger\">AND</span></strong> <i></i>",
+                    "text": " <strong><span class=\"text-danger\">AND</span></strong> <span class=\"label label-danger\">Criteria</span> <i></i>",
                     "icon": "glyphicon glyphicon-remove text-danger",
                     "state": {
                         "opened": true
                     },
                     "children": [
                         {
-                            "text": " <strong><span class=\"text-danger\">OR</span></strong> <i>system-auth</i>",
+                            "text": " <strong><span class=\"text-danger\">OR</span></strong> <span class=\"label label-danger\">Criteria</span> <i>system-auth</i>",
                             "icon": "glyphicon glyphicon-remove text-danger",
                             "state": {
                                 "opened": true
                             },
                             "children": [
                                 {
-                                    "text": " <strong><span class=\"text-danger\">accounts_passwords_pam_faillock_numeric_default_check_system-auth</span></strong> <i>Perform check if pam_faillock authfail follows pam_unix even with lines skipped</i>",
+                                    "text": " <strong><span class=\"text-danger\">accounts_passwords_pam_faillock_numeric_default_check_system-auth</span></strong> <span class=\"label label-danger\">Test</span> <i>Perform check if pam_faillock authfail follows pam_unix even with lines skipped</i>",
                                     "icon": "glyphicon glyphicon-remove text-danger",
                                     "state": {
                                         "opened": true
                                     }
                                 },
                                 {
-                                    "text": " <strong><span class=\"text-danger\">accounts_passwords_pam_faillock_authfail_deny_system-auth</span></strong> <i>Perform check if pam_faillock authfail follows pam_unix with either sufficient or default=ignore</i>",
+                                    "text": " <strong><span class=\"text-danger\">accounts_passwords_pam_faillock_authfail_deny_system-auth</span></strong> <span class=\"label label-danger\">Test</span> <i>Perform check if pam_faillock authfail follows pam_unix with either sufficient or default=ignore</i>",
                                     "icon": "glyphicon glyphicon-remove text-danger",
                                     "state": {
                                         "opened": true
@@ -71,21 +71,21 @@
                             ]
                         },
                         {
-                            "text": " <strong><span class=\"text-danger\">OR</span></strong> <i>password-auth</i>",
+                            "text": " <strong><span class=\"text-danger\">OR</span></strong> <span class=\"label label-danger\">Criteria</span> <i>password-auth</i>",
                             "icon": "glyphicon glyphicon-remove text-danger",
                             "state": {
                                 "opened": true
                             },
                             "children": [
                                 {
-                                    "text": " <strong><span class=\"text-danger\">accounts_passwords_pam_faillock_numeric_default_check_password-auth</span></strong> <i>Perform check if pam_faillock authfail follows pam_unix even with lines skipped</i>",
+                                    "text": " <strong><span class=\"text-danger\">accounts_passwords_pam_faillock_numeric_default_check_password-auth</span></strong> <span class=\"label label-danger\">Test</span> <i>Perform check if pam_faillock authfail follows pam_unix even with lines skipped</i>",
                                     "icon": "glyphicon glyphicon-remove text-danger",
                                     "state": {
                                         "opened": true
                                     }
                                 },
                                 {
-                                    "text": " <strong><span class=\"text-danger\">accounts_passwords_pam_faillock_authfail_deny_password-auth</span></strong> <i>pam_faillock.so authfail deny value set in password-auth</i>",
+                                    "text": " <strong><span class=\"text-danger\">accounts_passwords_pam_faillock_authfail_deny_password-auth</span></strong> <span class=\"label label-danger\">Test</span> <i>pam_faillock.so authfail deny value set in password-auth</i>",
                                     "icon": "glyphicon glyphicon-remove text-danger",
                                     "state": {
                                         "opened": true

--- a/tests/test_data/JsTree_json1.json
+++ b/tests/test_data/JsTree_json1.json
@@ -1,47 +1,47 @@
 {
-    "text": " <strong><span class=\"text-success\">rule_disable_host_auth</span></strong> <i>Disable Host-Based Authentication</i>",
+    "text": " <strong><span class=\"text-success\">rule_disable_host_auth</span></strong> <span class=\"label label-success\">Rule</span> <i>Disable Host-Based Authentication</i>",
     "icon": "glyphicon glyphicon-ok text-success",
     "state": {
         "opened": true
     },
     "children": [
         {
-            "text": " <strong><span class=\"text-success\">OR</span></strong> <i>SSH is configured correctly or is not installed</i>",
+            "text": " <strong><span class=\"text-success\">OR</span></strong> <span class=\"label label-success\">Definition</span> <i>SSH is configured correctly or is not installed</i>",
             "icon": "glyphicon glyphicon-ok text-success",
             "state": {
                 "opened": true
             },
             "children": [
                 {
-                    "text": " <strong><span class=\"text-danger\">AND</span></strong> <i>sshd is not installed</i>",
+                    "text": " <strong><span class=\"text-danger\">AND</span></strong> <span class=\"label label-danger\">Criteria</span> <i>sshd is not installed</i>",
                     "icon": "glyphicon glyphicon-remove text-danger",
                     "state": {
                         "opened": true
                     },
                     "children": [
                         {
-                            "text": " <strong><span class=\"text-success\">OR</span></strong> <i>sshd is not required or requirement is unset</i>",
+                            "text": " <strong><span class=\"text-success\">OR</span></strong> <span class=\"label label-success\">Extend definition</span> <i>sshd is not required or requirement is unset</i>",
                             "icon": "glyphicon glyphicon-ok text-success",
                             "state": {
                                 "opened": true
                             },
                             "children": [
                                 {
-                                    "text": " <strong><span class=\"text-danger\">sshd_not_required</span></strong> <i></i>",
+                                    "text": " <strong><span class=\"text-danger\">sshd_not_required</span></strong> <span class=\"label label-danger\">Test</span> <i></i>",
                                     "icon": "glyphicon glyphicon-remove text-danger",
                                     "state": {
                                         "opened": true
                                     }
                                 },
                                 {
-                                    "text": " <strong><span class=\"text-success\">AND</span></strong> <i>SSH requirement is unset</i>",
+                                    "text": " <strong><span class=\"text-success\">AND</span></strong> <span class=\"label label-success\">Extend definition</span> <i>SSH requirement is unset</i>",
                                     "icon": "glyphicon glyphicon-ok text-success",
                                     "state": {
                                         "opened": true
                                     },
                                     "children": [
                                         {
-                                            "text": " <strong><span class=\"text-success\">sshd_requirement_unset</span></strong> <i></i>",
+                                            "text": " <strong><span class=\"text-success\">sshd_requirement_unset</span></strong> <span class=\"label label-success\">Test</span> <i></i>",
                                             "icon": "glyphicon glyphicon-ok text-success",
                                             "state": {
                                                 "opened": true
@@ -52,14 +52,14 @@
                             ]
                         },
                         {
-                            "text": " <strong><span class=\"text-danger\">AND</span></strong> <i>rpm package openssh-server removed</i>",
+                            "text": " <strong><span class=\"text-danger\">AND</span></strong> <span class=\"label label-danger\">Extend definition</span> <i>rpm package openssh-server removed</i>",
                             "icon": "glyphicon glyphicon-remove text-danger",
                             "state": {
                                 "opened": true
                             },
                             "children": [
                                 {
-                                    "text": " <strong><span class=\"text-danger\">package_openssh-server_removed</span></strong> <i>package openssh-server is removed</i>",
+                                    "text": " <strong><span class=\"text-danger\">package_openssh-server_removed</span></strong> <span class=\"label label-danger\">Test</span> <i>package openssh-server is removed</i>",
                                     "icon": "glyphicon glyphicon-remove text-danger",
                                     "state": {
                                         "opened": true
@@ -70,35 +70,35 @@
                     ]
                 },
                 {
-                    "text": " <strong><span class=\"text-success\">AND</span></strong> <i>sshd is installed and configured</i>",
+                    "text": " <strong><span class=\"text-success\">AND</span></strong> <span class=\"label label-success\">Criteria</span> <i>sshd is installed and configured</i>",
                     "icon": "glyphicon glyphicon-ok text-success",
                     "state": {
                         "opened": true
                     },
                     "children": [
                         {
-                            "text": " <strong><span class=\"text-success\">OR</span></strong> <i>sshd is required or requirement is unset</i>",
+                            "text": " <strong><span class=\"text-success\">OR</span></strong> <span class=\"label label-success\">Extend definition</span> <i>sshd is required or requirement is unset</i>",
                             "icon": "glyphicon glyphicon-ok text-success",
                             "state": {
                                 "opened": true
                             },
                             "children": [
                                 {
-                                    "text": " <strong><span class=\"text-danger\">sshd_required</span></strong> <i></i>",
+                                    "text": " <strong><span class=\"text-danger\">sshd_required</span></strong> <span class=\"label label-danger\">Test</span> <i></i>",
                                     "icon": "glyphicon glyphicon-remove text-danger",
                                     "state": {
                                         "opened": true
                                     }
                                 },
                                 {
-                                    "text": " <strong><span class=\"text-success\">AND</span></strong> <i>SSH requirement is unset</i>",
+                                    "text": " <strong><span class=\"text-success\">AND</span></strong> <span class=\"label label-success\">Extend definition</span> <i>SSH requirement is unset</i>",
                                     "icon": "glyphicon glyphicon-ok text-success",
                                     "state": {
                                         "opened": true
                                     },
                                     "children": [
                                         {
-                                            "text": " <strong><span class=\"text-success\">sshd_requirement_unset</span></strong> <i></i>",
+                                            "text": " <strong><span class=\"text-success\">sshd_requirement_unset</span></strong> <span class=\"label label-success\">Test</span> <i></i>",
                                             "icon": "glyphicon glyphicon-ok text-success",
                                             "state": {
                                                 "opened": true
@@ -109,14 +109,14 @@
                             ]
                         },
                         {
-                            "text": " <strong><span class=\"text-success\">AND</span></strong> <i>rpm package openssh-server installed</i>",
+                            "text": " <strong><span class=\"text-success\">AND</span></strong> <span class=\"label label-success\">Extend definition</span> <i>rpm package openssh-server installed</i>",
                             "icon": "glyphicon glyphicon-ok text-success",
                             "state": {
                                 "opened": true
                             },
                             "children": [
                                 {
-                                    "text": " <strong><span class=\"text-success\">package_openssh-server_installed</span></strong> <i>package openssh-server is installed</i>",
+                                    "text": " <strong><span class=\"text-success\">package_openssh-server_installed</span></strong> <span class=\"label label-success\">Test</span> <i>package openssh-server is installed</i>",
                                     "icon": "glyphicon glyphicon-ok text-success",
                                     "state": {
                                         "opened": true
@@ -125,7 +125,7 @@
                             ]
                         },
                         {
-                            "text": " <strong><span class=\"text-success\">sshd_hostbasedauthentication</span></strong> <i>Check HostbasedAuthentication in /etc/ssh/sshd_config</i>",
+                            "text": " <strong><span class=\"text-success\">sshd_hostbasedauthentication</span></strong> <span class=\"label label-success\">Test</span> <i>Check HostbasedAuthentication in /etc/ssh/sshd_config</i>",
                             "icon": "glyphicon glyphicon-ok text-success",
                             "state": {
                                 "opened": true

--- a/tests/test_data/add_to_tree.json
+++ b/tests/test_data/add_to_tree.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "and",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/bigOvalTree.json
+++ b/tests/test_data/bigOvalTree.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "and",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,14 +20,16 @@
             "type": "operator",
             "value": "xor",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": [
                 {
                     "node_id": 4,
                     "type": "value",
                     "value": "true",
                     "negation": false,
-                    "comment":null,
+                    "comment": null,
+                    "tag": null,
                     "child": null
                 },
                 {
@@ -33,14 +37,16 @@
                     "type": "operator",
                     "value": "one",
                     "negation": false,
-                    "comment":null,
+                    "comment": null,
+                    "tag": null,
                     "child": [
                         {
                             "node_id": 6,
                             "type": "value",
                             "value": "noteval",
                             "negation": false,
-                            "comment":null,
+                            "comment": null,
+                            "tag": null,
                             "child": null
                         },
                         {
@@ -48,7 +54,8 @@
                             "type": "value",
                             "value": "true",
                             "negation": false,
-                            "comment":null,
+                            "comment": null,
+                            "tag": null,
                             "child": null
                         },
                         {
@@ -56,7 +63,8 @@
                             "type": "value",
                             "value": "notappl",
                             "negation": false,
-                            "comment":null,
+                            "comment": null,
+                            "tag": null,
                             "child": null
                         }
                     ]
@@ -66,7 +74,8 @@
                     "type": "value",
                     "value": "error",
                     "negation": false,
-                    "comment":null,
+                    "comment": null,
+                    "tag": null,
                     "child": null
                 }
             ]
@@ -76,14 +85,16 @@
             "type": "operator",
             "value": "or",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": [
                 {
                     "node_id": 11,
                     "type": "value",
                     "value": "unknown",
                     "negation": false,
-                    "comment":null,
+                    "comment": null,
+                    "tag": null,
                     "child": null
                 },
                 {
@@ -91,7 +102,8 @@
                     "type": "value",
                     "value": "true",
                     "negation": false,
-                    "comment":null,
+                    "comment": null,
+                    "tag": null,
                     "child": null
                 }
             ]

--- a/tests/test_data/referenc_result_data_json.json
+++ b/tests/test_data/referenc_result_data_json.json
@@ -11,7 +11,7 @@
                 "type": "operator",
                 "value": "and",
                 "negation": false,
-                "comment": null,
+                "comment": "The RPM package abrt should be removed.",
                 "child": [
                     {
                         "node_id": "oval:ssg-test_package_abrt_removed:tst:1",

--- a/tests/test_data/referenc_result_data_json.json
+++ b/tests/test_data/referenc_result_data_json.json
@@ -5,6 +5,7 @@
         "value": "and",
         "negation": false,
         "comment": "Package abrt Removed",
+        "tag": "Rule",
         "child": [
             {
                 "node_id": "oval:ssg-package_abrt_removed:def:1",
@@ -12,6 +13,7 @@
                 "value": "and",
                 "negation": false,
                 "comment": "The RPM package abrt should be removed.",
+                "tag": "Definition",
                 "child": [
                     {
                         "node_id": "oval:ssg-test_package_abrt_removed:tst:1",
@@ -19,6 +21,7 @@
                         "value": "false",
                         "negation": false,
                         "comment": "package abrt is removed",
+                        "tag": "Test",
                         "child": null
                     }
                 ]

--- a/tests/test_data/rule_dict.json
+++ b/tests/test_data/rule_dict.json
@@ -1,26 +1,29 @@
 {
     "rule_id": "xccdf_org.ssgproject.content_rule_dconf_gnome_session_idle_user_locks",
     "definition": {
-        "comment": "Ensure Users Cannot Change GNOME3 Session Idle Settings",
         "id": "oval:ssg-dconf_gnome_session_idle_user_locks:def:1",
+        "comment": "Ensure Users Cannot Change GNOME3 Session Idle Settings",
         "node": [
             {
                 "operator": "OR",
                 "negate": false,
                 "result": "false",
                 "comment": "Ensure that users cannot change GNOME3 session idle settings.",
+                "tag": "Definition",
                 "node": [
                     {
                         "operator": "AND",
                         "negate": true,
                         "result": "true",
                         "comment": "dconf installed",
+                        "tag": "Extend definition",
                         "node": [
                             {
                                 "value_id": "oval:ssg-test_package_dconf_installed:tst:1",
                                 "value": "true",
                                 "negate": false,
-                                "comment": "package dconf is installed"
+                                "comment": "package dconf is installed",
+                                "tag": "Test"
                             }
                         ]
                     },
@@ -29,24 +32,28 @@
                         "negate": false,
                         "result": "false",
                         "comment": "check screensaver idle delay and prevent user from changing it",
+                        "tag": "Criteria",
                         "node": [
                             {
                                 "operator": "OR",
                                 "negate": false,
                                 "result": "true",
                                 "comment": "dconf user profile exists",
+                                "tag": "Extend definition",
                                 "node": [
                                     {
                                         "operator": "AND",
                                         "negate": true,
                                         "result": "true",
                                         "comment": "dconf installed",
+                                        "tag": "Extend definition",
                                         "node": [
                                             {
                                                 "value_id": "oval:ssg-test_package_dconf_installed:tst:1",
                                                 "value": "true",
                                                 "negate": false,
-                                                "comment": "package dconf is installed"
+                                                "comment": "package dconf is installed",
+                                                "tag": "Test"
                                             }
                                         ]
                                     },
@@ -54,7 +61,8 @@
                                         "value_id": "oval:ssg-test_dconf_user_profile:tst:1",
                                         "value": "true",
                                         "negate": false,
-                                        "comment": "dconf user profile exists"
+                                        "comment": "dconf user profile exists",
+                                        "tag": "Test"
                                     }
                                 ]
                             },
@@ -62,7 +70,8 @@
                                 "value_id": "oval:ssg-test_user_change_idle_delay_lock:tst:1",
                                 "value": "false",
                                 "negate": false,
-                                "comment": "prevent user from changing idle delay"
+                                "comment": "prevent user from changing idle delay",
+                                "tag": "Test"
                             }
                         ]
                     }

--- a/tests/test_data/rule_dict.json
+++ b/tests/test_data/rule_dict.json
@@ -8,7 +8,7 @@
                 "operator": "OR",
                 "negate": false,
                 "result": "false",
-                "comment": null,
+                "comment": "Ensure that users cannot change GNOME3 session idle settings.",
                 "node": [
                     {
                         "operator": "AND",

--- a/tests/test_data/test_data_and/ANDTreeError.json
+++ b/tests/test_data/test_data_and/ANDTreeError.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "and",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "error",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "error",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -42,7 +47,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -50,7 +56,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "error",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_and/ANDTreeFalse.json
+++ b/tests/test_data/test_data_and/ANDTreeFalse.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "and",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "error",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -42,7 +47,8 @@
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -50,7 +56,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_and/ANDTreeNotappl.json
+++ b/tests/test_data/test_data_and/ANDTreeNotappl.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "and",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_and/ANDTreeNoteval.json
+++ b/tests/test_data/test_data_and/ANDTreeNoteval.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "and",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -42,7 +47,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -50,7 +56,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_and/ANDTreeTrue.json
+++ b/tests/test_data/test_data_and/ANDTreeTrue.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "and",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_and/ANDTreeUnknown.json
+++ b/tests/test_data/test_data_and/ANDTreeUnknown.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "and",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -42,7 +47,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -50,7 +56,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_one/ONETreeError.json
+++ b/tests/test_data/test_data_one/ONETreeError.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "one",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "error",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "error",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -42,7 +47,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -50,7 +56,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_one/ONETreeFalse.json
+++ b/tests/test_data/test_data_one/ONETreeFalse.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "one",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "error",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -42,7 +47,8 @@
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -50,7 +56,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_one/ONETreeFalse1.json
+++ b/tests/test_data/test_data_one/ONETreeFalse1.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "one",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_one/ONETreeNotappl.json
+++ b/tests/test_data/test_data_one/ONETreeNotappl.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "one",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_one/ONETreeNoteval.json
+++ b/tests/test_data/test_data_one/ONETreeNoteval.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "one",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -42,7 +47,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -50,7 +56,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_one/ONETreeTrue.json
+++ b/tests/test_data/test_data_one/ONETreeTrue.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "one",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_one/ONETreeUnknown.json
+++ b/tests/test_data/test_data_one/ONETreeUnknown.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "one",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -42,7 +47,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -50,7 +56,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_or/ORTreeError.json
+++ b/tests/test_data/test_data_or/ORTreeError.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "or",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "error",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "error",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -42,7 +47,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -50,7 +56,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "error",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_or/ORTreeFalse.json
+++ b/tests/test_data/test_data_or/ORTreeFalse.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "or",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_or/ORTreeNotappl.json
+++ b/tests/test_data/test_data_or/ORTreeNotappl.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "or",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_or/ORTreeNoteval.json
+++ b/tests/test_data/test_data_or/ORTreeNoteval.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "or",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -42,7 +47,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -50,7 +56,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_or/ORTreeTrue.json
+++ b/tests/test_data/test_data_or/ORTreeTrue.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "or",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "error",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -42,7 +47,8 @@
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -50,7 +56,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_or/ORTreeUnknown.json
+++ b/tests/test_data/test_data_or/ORTreeUnknown.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "or",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -42,7 +47,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -50,7 +56,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_xor/XORTreeError.json
+++ b/tests/test_data/test_data_xor/XORTreeError.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "xor",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "error",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "error",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -42,14 +47,16 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
             "node_id": 7,
             "type": "value",
             "value": "notappl",
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "negation": false,
             "child": null
         },
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_xor/XORTreeFalse.json
+++ b/tests/test_data/test_data_xor/XORTreeFalse.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "xor",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -42,7 +47,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -50,7 +56,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_xor/XORTreeNotappl.json
+++ b/tests/test_data/test_data_xor/XORTreeNotappl.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "xor",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_xor/XORTreeNoteval.json
+++ b/tests/test_data/test_data_xor/XORTreeNoteval.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "xor",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,14 +38,16 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
             "node_id": 6,
             "type": "value",
             "value": "noteval",
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "negation": false,
             "child": null
         },
@@ -50,7 +56,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_xor/XORTreeTrue.json
+++ b/tests/test_data/test_data_xor/XORTreeTrue.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "xor",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "false",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -42,7 +47,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -50,7 +56,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_data/test_data_xor/XORTreeUnknown.json
+++ b/tests/test_data/test_data_xor/XORTreeUnknown.json
@@ -3,14 +3,16 @@
     "type": "operator",
     "value": "xor",
     "negation": false,
-    "comment":null,
+    "comment": null,
+    "tag": null,
     "child": [
         {
             "node_id": 2,
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -18,7 +20,8 @@
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -26,7 +29,8 @@
             "type": "value",
             "value": "true",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -34,7 +38,8 @@
             "type": "value",
             "value": "unknown",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -42,7 +47,8 @@
             "type": "value",
             "value": "noteval",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -50,7 +56,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         },
         {
@@ -58,7 +65,8 @@
             "type": "value",
             "value": "notappl",
             "negation": false,
-            "comment":null,
+            "comment": null,
+            "tag": null,
             "child": null
         }
     ]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -52,11 +52,11 @@ def bad_tree():
          t
     """
     t = OvalNode(
-        1, "value", "true", False, None, [
+        1, "value", "true", False, None, None,  [
            OvalNode(
-               2, "operator", "and", False, None, [
+               2, "operator", "and", False, None, None,  [
                    OvalNode(
-                       3, "value", "true", False, None)])])
+                       3, "value", "true", False, None, None)])])
     return
 
 
@@ -64,7 +64,7 @@ def tree_only_or():
     """
         or
     """
-    Tree = OvalNode(1, "operator", 'or', False, None)
+    Tree = OvalNode(1, "operator", 'or', False, None, None)
     return
 
 
@@ -72,28 +72,28 @@ def tree_only_and():
     """
         and
     """
-    Tree = OvalNode(1, "operator", 'and', False, None)
+    Tree = OvalNode(1, "operator", 'and', False, None, None)
     return
 
 
 def tree_with_bad_value_of_operator():
-    Tree = OvalNode(1, "operator", 'nad', False, None)
+    Tree = OvalNode(1, "operator", 'nad', False, None, None)
     return
 
 
 def tree_with_bad_value_of_value():
-    Tree = OvalNode(1, "value", 'and', False, None)
+    Tree = OvalNode(1, "value", 'and', False, None, None)
     return
 
 
 def tree_with_bad_type():
-    Tree = OvalNode(1, "car", 'and', False, None)
+    Tree = OvalNode(1, "car", 'and', False, None, None)
     return
 
 
 def tree_with_bad_value_of_negation():
-    Tree = OvalNode(1, "operator", "true", False, None, [
-        OvalNode(2, "value", 'true', "random_string", None)])
+    Tree = OvalNode(1, "operator", "true", False, None, None,  [
+        OvalNode(2, "value", 'true', "random_string", None, None)])
     return
 
 # normal trees
@@ -101,29 +101,29 @@ def tree_with_bad_value_of_negation():
 
 def test_UPPERCASETree():
     t = OvalNode(
-        1, "OPERATOR", "AND", False, None, [
+        1, "OPERATOR", "AND", False, None, None,  [
            OvalNode(
-               2, "VALUE", "TRUE", False, None), OvalNode(
-               3, "VALUE", "NOTAPPL", False, None)])
+               2, "VALUE", "TRUE", False, None, None), OvalNode(
+               3, "VALUE", "NOTAPPL", False, None, None)])
 
 
 def test_bigOvalTree():
-    Tree = OvalNode(1, 'operator', 'and', False, None, [
-        OvalNode(2, 'value', "false", False, None),
-        OvalNode(3, 'operator', "xor", False, None, [
-            OvalNode(4, 'value', 'true', False, None),
-            OvalNode(5, 'operator', 'one', False, None, [
-                OvalNode(6, 'value', 'noteval', False, None),
-                OvalNode(7, 'value', 'true', False, None),
-                OvalNode(8, 'value', 'notappl', False, None)
+    Tree = OvalNode(1, 'operator', 'and', False, None, None,  [
+        OvalNode(2, 'value', "false", False, None, None),
+        OvalNode(3, 'operator', "xor", False, None, None,  [
+            OvalNode(4, 'value', 'true', False, None, None),
+            OvalNode(5, 'operator', 'one', False, None, None,  [
+                OvalNode(6, 'value', 'noteval', False, None, None),
+                OvalNode(7, 'value', 'true', False, None, None),
+                OvalNode(8, 'value', 'notappl', False, None, None)
             ]
             ),
-            OvalNode(9, 'value', 'error', False, None)
+            OvalNode(9, 'value', 'error', False, None, None)
         ]
         ),
-        OvalNode(10, 'operator', 'or', False, None, [
-            OvalNode(11, 'value', "unknown", False, None),
-            OvalNode(12, 'value', "true", False, None)
+        OvalNode(10, 'operator', 'or', False, None, None,  [
+            OvalNode(11, 'value', "unknown", False, None, None),
+            OvalNode(12, 'value', "true", False, None, None)
         ]
         )
     ]
@@ -145,8 +145,8 @@ def test_treeRepr():
          |
          f
     """
-    Tree = OvalNode(1, 'operator', 'and', False, None, [
-        OvalNode(2, 'value', "false", False, None)
+    Tree = OvalNode(1, 'operator', 'and', False, None, None,  [
+        OvalNode(2, 'value', "false", False, None, None)
     ]
     )
     assert str(Tree) == "and"
@@ -162,11 +162,11 @@ def test_add_to_tree():
     test_data_src = 'test_data/add_to_tree.json'
     dict_of_tree = tests.any_test_help.any_get_test_data_json(test_data_src)
 
-    Tree = OvalNode(1, 'operator', 'and', False, None, [
-        OvalNode(2, 'value', "false", False, None)
+    Tree = OvalNode(1, 'operator', 'and', False, None, None,  [
+        OvalNode(2, 'value', "false", False, None, None)
     ]
     )
-    Tree1 = OvalNode(3, 'value', "true", False, None)
+    Tree1 = OvalNode(3, 'value', "true", False, None, None)
     Tree.add_to_tree(1, Tree1)
     assert Tree.save_tree_to_dict() == dict_of_tree
 
@@ -179,12 +179,12 @@ def test_ChangeValueTree():
           / \
          f   t
     """
-    Tree = OvalNode(1, 'operator', 'and', False, None, [
-        OvalNode(2, 'value', "true", False, None),
-        OvalNode(3, 'value', "false", False, None),
-        OvalNode(4, 'operator', 'or', False, None, [
-            OvalNode(5, 'value', "false", False, None),
-            OvalNode(6, 'value', "true", False, None)
+    Tree = OvalNode(1, 'operator', 'and', False, None, None,  [
+        OvalNode(2, 'value', "true", False, None, None),
+        OvalNode(3, 'value', "false", False, None, None),
+        OvalNode(4, 'operator', 'or', False, None, None,  [
+            OvalNode(5, 'value', "false", False, None, None),
+            OvalNode(6, 'value', "true", False, None, None)
         ]
         )
     ]
@@ -200,8 +200,8 @@ def test_node_operator_negate():
          |
          f
     """
-    Tree = OvalNode(1, 'operator', 'and', True, None, [
-        OvalNode(2, 'value', "false", False, None)
+    Tree = OvalNode(1, 'operator', 'and', True, None, None,  [
+        OvalNode(2, 'value', "false", False, None, None)
     ]
     )
     tests.any_test_help.any_test_treeEvaluation_with_tree(Tree, "true")
@@ -213,8 +213,8 @@ def test_node_operator_negate1():
          |
          t
     """
-    Tree = OvalNode(1, 'operator', 'and', False, None, [
-        OvalNode(2, 'value', "true", False, None)
+    Tree = OvalNode(1, 'operator', 'and', False, None, None,  [
+        OvalNode(2, 'value', "true", False, None, None)
     ]
     )
     tests.any_test_help.any_test_treeEvaluation_with_tree(Tree, "true")
@@ -226,8 +226,8 @@ def test_node_operator_negate1():
          |
          t
     """
-    Tree = OvalNode(1, 'operator', 'and', False, None, [
-        OvalNode(2, 'value', "true", False, None)
+    Tree = OvalNode(1, 'operator', 'and', False, None, None,  [
+        OvalNode(2, 'value', "true", False, None, None)
     ]
     )
     tests.any_test_help.any_test_treeEvaluation_with_tree(Tree, "true")
@@ -239,8 +239,8 @@ def test_node_value_negate():
          |
          !f
     """
-    Tree = OvalNode(1, 'operator', 'and', False, None, [
-        OvalNode(2, 'value', "True", True, None)
+    Tree = OvalNode(1, 'operator', 'and', False, None, None,  [
+        OvalNode(2, 'value', "True", True, None, None)
     ]
     )
     tests.any_test_help.any_test_treeEvaluation_with_tree(Tree, "true")
@@ -252,8 +252,8 @@ def test_node_value_negate1():
          |
          !t
     """
-    Tree = OvalNode(1, 'operator', 'and', False, None, [
-        OvalNode(2, 'value', "false", True, None)
+    Tree = OvalNode(1, 'operator', 'and', False, None, None,  [
+        OvalNode(2, 'value', "false", True, None, None)
     ]
     )
     tests.any_test_help.any_test_treeEvaluation_with_tree(Tree, "false")


### PR DESCRIPTION
This PR contains:
- labels with information about node type. (Rule/Definition/Extend definition/Criteria/Test)
- Description of oval-def in second node
 
Fixes: #21 #43 