### PR TITLE
Append Fedora 32 to PackIt test and build

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,6 +19,10 @@ jobs:
 - job: propose_downstream
   trigger: release
   metadata:
+    dist-git-branch: f32
+- job: propose_downstream
+  trigger: release
+  metadata:
     dist-git-branch: f31
 - job: propose_downstream
   trigger: release
@@ -30,6 +34,7 @@ jobs:
     targets:
     - fedora-30-x86_64
     - fedora-31-x86_64
+    - fedora-32-x86_64
     - fedora-rawhide-x86_64
 - job: tests
   trigger: pull_request
@@ -37,4 +42,5 @@ jobs:
     targets:
     - fedora-30-x86_64
     - fedora-31-x86_64
+    - fedora-32-x86_64
     - fedora-rawhide-x86_64


### PR DESCRIPTION
This PR appends Fedora 32 to PackIt config. 