### PR TITLE
Fix notchecked rules

### DIFF
--- a/oval_graph/arf_to_html.py
+++ b/oval_graph/arf_to_html.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from .client import Client
 from .converter import Converter
-
+from .exceptions import NotChecked
 
 class ArfToHtml(Client):
     def __init__(self, args):
@@ -27,12 +27,13 @@ class ArfToHtml(Client):
     def prepare_data(self, rules):
         out = []
         for rule in rules['rules']:
-            oval_tree_dict = self.create_dict_of_rule(rule)
-            src = self.get_save_src(rule)
-            self.save_html_report(oval_tree_dict, src)
-            self.open_web_browser(src)
-            print('Rule "{}" done!'.format(rule))
-            out.append(src)
+            try:
+                oval_tree_dict = self.create_dict_of_rule(rule)
+                src = self.get_save_src(rule)
+                self.save_html_and_open_html(
+                    oval_tree_dict, src, rule, out)
+            except NotChecked as error:
+                self.print_red_text(error)
         return out
 
     def prepare_parser(self):

--- a/oval_graph/arf_to_json.py
+++ b/oval_graph/arf_to_json.py
@@ -9,7 +9,7 @@ import uuid
 
 from .converter import Converter
 from .client import Client
-
+from .exceptions import NotChecked
 
 class ArfToJson(Client):
     def __init__(self, args):
@@ -46,8 +46,12 @@ class ArfToJson(Client):
         out_oval_tree_dict = dict()
         for rule in rules['rules']:
             date = str(datetime.now().strftime("-%d_%m_%Y-%H_%M_%S"))
-            out_oval_tree_dict['graph-of-' + rule +
-                               date] = self.create_dict_of_rule(rule)
+            try:
+                out_oval_tree_dict['graph-of-' + rule +
+                                   date] = self.create_dict_of_rule(rule)
+            except NotChecked as error:
+                out_oval_tree_dict['graph-of-' + rule +
+                                   date] = str(error)
         if self.out is not None:
             self.save_dict_as_json(out_oval_tree_dict, self.out)
             out.append(self.out)

--- a/oval_graph/client.py
+++ b/oval_graph/client.py
@@ -36,6 +36,11 @@ class Client():
         }
         return MESSAGES
 
+    def print_red_text(self, text):
+        CRED = '\033[91m'
+        CEND = '\033[0m'
+        print(CRED + str(text) + CEND)
+
     def run_gui_and_return_answers(self):
         if self.isatty:
             if self.all_rules:
@@ -133,6 +138,12 @@ class Client():
             raise ValueError('404 rule "{}" not found!'.format(self.rule_name))
         else:
             return rules
+
+    def save_html_and_open_html(self, oval_tree_dict, src, rule, out):
+        self.save_html_report(oval_tree_dict, src)
+        print('Rule "{}" done!'.format(rule))
+        out.append(src)
+        self.open_web_browser(src)
 
     def open_web_browser(self, src):
         if not self.off_webbrowser:

--- a/oval_graph/exceptions.py
+++ b/oval_graph/exceptions.py
@@ -1,0 +1,3 @@
+class NotChecked(Exception):
+    """Raised when rule is notchecked"""
+    pass

--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -106,3 +106,13 @@ def test_use_bat_report_file():
 
     with pytest.raises(Exception, match=r"arf\b|ARF\b"):
         assert tests.any_test_help.get_parser(src)
+
+
+def test_get_def_id_by_notchecked_rule_id():
+    src = 'test_data/arf-scan-with-notchecked-rule.xml'
+
+    parser = tests.any_test_help.get_parser(src)
+    rule_id = 'xccdf_org.ssgproject.content_rule_security_patches_up_to_date'
+
+    with pytest.raises(Exception, match="notchecked"):
+        assert parser._get_definition_of_rule(rule_id)


### PR DESCRIPTION
This PR fixes a problem with unchecked rules (test file: ```tests/test_data/arf-scan-with-notchecked-rule.xml``` Rule:```xccdf_org.ssgproject.content_rule_security_patches_up_to_date```). The problem was caused by processing all rules. There was an interrupt while processing an unchecked rule. The same problem occurred when trying to process only an unchecked rule.