### PR TITLE
Fix processing negation

### DIFF
--- a/oval_graph/_xml_parser_oval_scan_definitions.py
+++ b/oval_graph/_xml_parser_oval_scan_definitions.py
@@ -28,12 +28,28 @@ class _XmlParserScanDefinitions:
             negate_status = str_to_bool[node.get('negate')]
         return negate_status
 
+    def _get_result(self, negate_status, tree):
+        """
+            This  method  removes  the  negation of
+            the result. Because negation is already
+            included in the result in ARF file.
+        """
+        result = tree.get('result')
+        reverse_negate_value = {
+            'true': 'false',
+            'false': 'true',
+        }
+        if negate_status and result in ('true', 'false'):
+            result = reverse_negate_value[result]
+        return result
+
     def _build_node(self, tree, tag, id_definition=None):
+        negate_status = self._get_negate_status(tree)
         node = dict(
             id=id_definition,
             operator=tree.get('operator'),
-            negate=self._get_negate_status(tree),
-            result=tree.get('result'),
+            negate=negate_status,
+            result=self._get_result(negate_status, tree),
             comment=None,
             tag=tag,
             node=[],
@@ -43,7 +59,7 @@ class _XmlParserScanDefinitions:
                 node['node'].append(self._build_node(child, "Criteria"))
             else:
                 negate_status = self._get_negate_status(child)
-                result_of_node = child.get('result')
+                result_of_node = self._get_result(negate_status, child)
                 if child.get('definition_ref') is not None:
                     node['node'].append(
                         dict(

--- a/oval_graph/converter.py
+++ b/oval_graph/converter.py
@@ -33,7 +33,7 @@ class Converter():
         if isinstance(tree, OvalNode):
             self.tree = tree
             self.result = self.tree.evaluate_tree()
-            if not self.result:
+            if self.tree.node_type == 'value':
                 self.result = self.tree.value
         else:
             raise ValueError(
@@ -42,8 +42,8 @@ class Converter():
     def _get_node_icon(self):
         values = self._get_node_style()
         return dict(
-            color=self.VALUE_TO_BOOTSTRAP_COLOR[values['negation_color']],
-            icon=self.VALUE_TO_ICON[values['test_value']],
+            color=self.VALUE_TO_BOOTSTRAP_COLOR[values['test_value']],
+            icon=self.VALUE_TO_ICON[values['negation_color']],
         )
 
     def get_comment(self):
@@ -77,7 +77,7 @@ class Converter():
                    label=label['str'],
                    color_tag=self.BOOTSTRAP_COLOR_TO_LABEL_COLOR[icons['color']],
                    tag=self.get_tag(),
-                   result=self.result,
+                   result=self._get_not_negate_result(),
                    comment=self.get_comment()),
                "icon": icons['icon'],
                "state": {"opened": self._show_node(hide_passing_tests)},
@@ -88,16 +88,17 @@ class Converter():
                 hide_passing_tests) for child in self.tree.children]
         return out
 
+    def _get_not_negate_result(self):
+        if self.tree.negation and self.tree.node_type == 'operator' and self.is_bool(
+                self.result):
+            return self.negate_bool(self.result)
+        return self.result
+
     def _show_node(self, hide_passing_tests):
-        value = self.tree.evaluate_tree()
-        if value is None:
-            value = self.tree.value
-        if value == 'true' and hide_passing_tests:
-            return False
-        return True
+        return not(self.result == 'true' and hide_passing_tests)
 
     def _get_node_style(self):
-        value = self.result
+        value = self._get_not_negate_result()
         out_color = None
         if self.tree.negation and self.is_bool(value):
             out_color = self.negate_bool(value)
@@ -116,23 +117,27 @@ class Converter():
     def _get_label(self):
         out = dict(negation=None, str="")
         if self.tree.node_type == 'value':
-            if self.tree.negation:
-                out['negation'] = self.get_negation_character(self.tree.value)
+            out['negation'] = self._get_negation_for_label_of_value()
             out['str'] = re.sub(
                 '(oval:ssg-test_|oval:ssg-)|(:def:1|:tst:1)', '', str(self.tree.node_id))
-            return out
         else:
             if str(self.tree.node_id).startswith('xccdf_org'):
                 out['str'] = re.sub(
                     '(xccdf_org.ssgproject.content_)', '', str(
                         self.tree.node_id))
-                return out
             else:
-                if self.tree.negation:
-                    out['negation'] = self.get_negation_character(
-                        self.tree.evaluate_tree())
+                out['negation'] = self._get_negation_for_label_of_operator()
                 out['str'] = (self.tree.value).upper()
-                return out
+        return out
+
+    def _get_negation_for_label_of_value(self):
+        if self.tree.negation and self.is_bool(self.tree.value):
+            return self.get_negation_character(
+                self.negate_bool(self.tree.value))
+
+    def _get_negation_for_label_of_operator(self):
+        if self.tree.negation and self.is_bool(self.result):
+            return self.get_negation_character(self.result)
 
     def negate_bool(self, value):
         values = {
@@ -142,6 +147,4 @@ class Converter():
         return values[str(value)]
 
     def is_bool(self, value):
-        if value == "true" or value == "false":
-            return True
-        return False
+        return value == "true" or value == "false"

--- a/tests/test_JsTree_data/JsTree_data_negated_0.json
+++ b/tests/test_JsTree_data/JsTree_data_negated_0.json
@@ -1,5 +1,5 @@
 {
-    "text": "<strong><span class=\"text-success\">NOT</strong></span> <strong><span class=\"text-danger\">AND</span></strong> <span class=\"label label-danger\"></span> <span class=\"label label-danger\">true</span> <i></i>",
+    "text": "<strong><span class=\"text-success\">NOT</strong></span> <strong><span class=\"text-danger\">AND</span></strong> <span class=\"label label-danger\"></span> <span class=\"label label-danger\">false</span> <i></i>",
     "icon": "glyphicon glyphicon-ok text-success",
     "state": {
         "opened": true

--- a/tests/test_JsTree_data/JsTree_data_negated_1.json
+++ b/tests/test_JsTree_data/JsTree_data_negated_1.json
@@ -1,5 +1,5 @@
 {
-    "text": "<strong><span class=\"text-danger\">NOT</strong></span> <strong><span class=\"text-success\">AND</span></strong> <span class=\"label label-success\"></span> <span class=\"label label-success\">false</span> <i></i>",
+    "text": "<strong><span class=\"text-danger\">NOT</strong></span> <strong><span class=\"text-success\">AND</span></strong> <span class=\"label label-success\"></span> <span class=\"label label-success\">true</span> <i></i>",
     "icon": "glyphicon glyphicon-remove text-danger",
     "state": {
         "opened": true

--- a/tests/test_JsTree_data/JsTree_data_negated_2.json
+++ b/tests/test_JsTree_data/JsTree_data_negated_2.json
@@ -1,6 +1,6 @@
 {
-    "text": "<strong><span class=\"text-success\">NOT</strong></span> <strong><span class=\"text-danger\">2</span></strong> <span class=\"label label-danger\"></span> <span class=\"label label-danger\">true</span> <i></i>",
-    "icon": "glyphicon glyphicon-ok text-success",
+    "text": "<strong><span class=\"text-danger\">NOT</strong></span> <strong><span class=\"text-success\">2</span></strong> <span class=\"label label-success\"></span> <span class=\"label label-success\">true</span> <i></i>",
+    "icon": "glyphicon glyphicon-remove text-danger",
     "state": {
         "opened": true
     },

--- a/tests/test_JsTree_data/JsTree_data_negated_3.json
+++ b/tests/test_JsTree_data/JsTree_data_negated_3.json
@@ -1,6 +1,6 @@
 {
-    "text": "<strong><span class=\"text-danger\">NOT</strong></span> <strong><span class=\"text-success\">2</span></strong> <span class=\"label label-success\"></span> <span class=\"label label-success\">false</span> <i></i>",
-    "icon": "glyphicon glyphicon-remove text-danger",
+    "text": "<strong><span class=\"text-success\">NOT</strong></span> <strong><span class=\"text-danger\">2</span></strong> <span class=\"label label-danger\"></span> <span class=\"label label-danger\">false</span> <i></i>",
+    "icon": "glyphicon glyphicon-ok text-success",
     "state": {
         "opened": true
     },


### PR DESCRIPTION
This PR fixes a problem with parsing negation. The problem is caused by saving the results of the negated test in ARF. Result of  negated test is negated whitch mean result of test has processed negation. When evaluating a tree, negation is processed. This results in double negation. 