### PR TITLE
Fixes requires

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,29 +12,40 @@ current_version_command: ["python3", "setup.py", "--version"]
 jobs:
 - job: sync_from_downstream
   trigger: commit
+
 - job: propose_downstream
   trigger: release
   metadata:
-    dist-git-branch: master
+    dist-git-branch: fedora-all
+
 - job: propose_downstream
   trigger: release
   metadata:
-    dist-git-branch: f31
+    dist-git-branch: epel7
+
 - job: propose_downstream
   trigger: release
   metadata:
-    dist-git-branch: f30
+    dist-git-branch: epel8
+
+- job: propose_downstream
+  trigger: release
+  metadata:
+    dist-git-branch: epel8-playground
+
 - job: copr_build
   trigger: pull_request
   metadata:
     targets:
-    - fedora-30-x86_64
-    - fedora-31-x86_64
-    - fedora-rawhide-x86_64
+    - fedora-all
+    - epel-7-x86_64
+    - epel-8-x86_64
+
 - job: tests
   trigger: pull_request
   metadata:
     targets:
-    - fedora-30-x86_64
-    - fedora-31-x86_64
-    - fedora-rawhide-x86_64
+    - fedora-all
+# Disabled EPEL 7 install test because for install is used dnf on CentOS 7 
+#    - epel-7-x86_64
+    - epel-8-x86_64

--- a/oval-graph.spec
+++ b/oval-graph.spec
@@ -4,7 +4,7 @@
 Summary:            Tool for visualization of SCAP rule evaluation results
 Name:               %{name}
 Version:            1.1.0
-Release:            1%{?dist}
+Release:            2%{?dist}
 # The entire source code is ASL 2.0 except schemas/ which is Public Domain
 License:            ASL 2.0 and Public Domain
 
@@ -14,6 +14,7 @@ Source0:            https://files.pythonhosted.org/packages/source/o/%{name}/%{m
 BuildArch:          noarch
 
 BuildRequires:      python3-devel
+Requires:           python3-lxml
 
 %description
 Oval_graph is a tool that displays the results of evaluating SCAP rules.
@@ -43,6 +44,9 @@ Use `arf-to-json` to generate a rule result in json. Using the
 %{_bindir}/json-to-graph
 
 %changelog
+* Fri Apr 17 2020 Jan Rodak <jrodak@redhat.com> - 1.1.0-2
+- Fixes the required dependency
+
 * Wed Apr 15 2020 Jan Rodak <jrodak@redhat.com> - 1.1.0-1
 - release 1.1.0
 


### PR DESCRIPTION
This PR contains:
- fix for missing important dependency `python3-lxml` for rpm. Sometimes finding dependencies does not install important dependencies for the application.
- update packit config to test all supported OSs (in details of install test you could see installed dependency `python3-lxml`, which was missed before)