### PR TITLE
Uses explicitly build require python3-setuptools

### DIFF
--- a/oval-graph.spec
+++ b/oval-graph.spec
@@ -13,7 +13,7 @@ Source0:            https://files.pythonhosted.org/packages/source/o/%{name}/%{m
 
 BuildArch:          noarch
 
-BuildRequires:      python3-devel
+BuildRequires:      python3-devel, python3-setuptools
 Requires:           python3-lxml
 
 %description


### PR DESCRIPTION
This PR explicitly appends to spec file ```python3-setuptools``` because setuptools devs asked me to do it. Because it will helps with develop setuptools. 