### PR TITLE
Option --all-in-one in command json-to-graph

### DIFF
--- a/oval_graph/arf_to_html.py
+++ b/oval_graph/arf_to_html.py
@@ -3,7 +3,6 @@ from datetime import datetime
 
 from .client import Client
 from .converter import Converter
-from .exceptions import NotChecked
 
 
 class ArfToHtml(Client):
@@ -28,28 +27,12 @@ class ArfToHtml(Client):
         converter = Converter(self.xml_parser.get_oval_tree(rule_id))
         return converter.to_JsTree_dict(self.hide_passing_tests)
 
-    def _prepare_all_in_one_data(self, rules, dict_oval_trees, out, date):
-        for rule in rules['rules']:
-            try:
-                dict_oval_trees[
-                    'graph-of-' + rule + date] = self.create_dict_of_rule(rule)
-            except NotChecked as error:
-                self.print_red_text(error)
-        src = self.get_save_src('rules')
-        self.save_html_with_all_rules_in_one(
-            dict_oval_trees, src, rules, out)
-        return out
+    def _put_to_dict_oval_trees(self, dict_oval_trees, rule, date=None):
+        dict_oval_trees['graph-of-' + rule +
+                        date] = self.create_dict_of_rule(rule)
 
-    def _prepare_data_by_one(self, rules, dict_oval_trees, out, date):
-        for rule in rules['rules']:
-            try:
-                oval_tree_dict = self.create_dict_of_rule(rule)
-                src = self.get_save_src(rule + date)
-                self.save_html_and_open_html(
-                    oval_tree_dict, src, rule, out)
-            except NotChecked as error:
-                self.print_red_text(error)
-        return out
+    def _get_src_for_one_graph(self, rule, date=None):
+        return self.get_save_src(rule + date)
 
     def prepare_data(self, rules):
         out = []

--- a/oval_graph/arf_to_html.py
+++ b/oval_graph/arf_to_html.py
@@ -44,7 +44,7 @@ class ArfToHtml(Client):
         for rule in rules['rules']:
             try:
                 oval_tree_dict = self.create_dict_of_rule(rule)
-                src = self.get_save_src(rule)
+                src = self.get_save_src(rule + date)
                 self.save_html_and_open_html(
                     oval_tree_dict, src, rule, out)
             except NotChecked as error:

--- a/oval_graph/client.py
+++ b/oval_graph/client.py
@@ -9,6 +9,7 @@ from datetime import datetime
 import sys
 
 from .xml_parser import XmlParser
+from .exceptions import NotChecked
 
 
 class Client():
@@ -180,6 +181,28 @@ class Client():
         _dir = os.path.dirname(os.path.realpath(__file__))
         FIXTURE_DIR = os.path.join(_dir, src)
         return str(FIXTURE_DIR)
+
+    def _prepare_all_in_one_data(self, rules, dict_oval_trees, out, date=None):
+        for rule in rules['rules']:
+            try:
+                self._put_to_dict_oval_trees(dict_oval_trees, rule, date)
+            except NotChecked as error:
+                self.print_red_text(error)
+        src = self.get_save_src('rules')
+        self.save_html_with_all_rules_in_one(
+            dict_oval_trees, src, rules, out)
+        return out
+
+    def _prepare_data_by_one(self, rules, dict_oval_trees, out, date=None):
+        for rule in rules['rules']:
+            try:
+                oval_tree_dict = self.create_dict_of_rule(rule)
+                src = self._get_src_for_one_graph(rule, date)
+                self.save_html_and_open_html(
+                    oval_tree_dict, src, rule, out)
+            except NotChecked as error:
+                self.print_red_text(error)
+        return out
 
     def get_save_src(self, rule):
         if self.out is not None:

--- a/oval_graph/client.py
+++ b/oval_graph/client.py
@@ -182,15 +182,14 @@ class Client():
         return str(FIXTURE_DIR)
 
     def get_save_src(self, rule):
-        date = str(datetime.now().strftime("-%d_%m_%Y-%H_%M_%S"))
         if self.out is not None:
             os.makedirs(self.out, exist_ok=True)
             return os.path.join(
                 self.out,
-                'graph-of-' + rule + date + '.html')
+                'graph-of-' + rule + '.html')
         return os.path.join(
             os.getcwd(),
-            'graph-of-' + rule + date + '.html')
+            'graph-of-' + rule + '.html')
 
     def _get_part(self, part):
         with open(os.path.join(self.parts, part), "r") as data_file:

--- a/oval_graph/json_to_html.py
+++ b/oval_graph/json_to_html.py
@@ -91,38 +91,20 @@ class JsonToHtml(Client):
         self.oval_tree = self.load_json_to_oval_tree(rule)
         return self.create_dict_of_oval_node(self.oval_tree)
 
-    def _prepare_all_in_one_data(self, rules, dict_oval_trees, out):
-        for rule in rules['rules']:
-            try:
-                dict_oval_trees[
-                    rule] = self.create_dict_of_rule(rule)
-            except NotChecked as error:
-                self.print_red_text(error)
-        src = self.get_save_src('rules')
-        self.save_html_with_all_rules_in_one(
-            dict_oval_trees, src, rules, out)
-        return out
+    def _put_to_dict_oval_trees(self, dict_oval_trees, rule, date=None):
+        dict_oval_trees[rule] = self.create_dict_of_rule(rule)
 
-    def _prepare_data_by_one(self, rules, dict_oval_trees, out):
-        for rule in rules["rules"]:
-            try:
-                dict_oval_trees = self.create_dict_of_rule(rule)
-                src = self.get_save_src(
-                    rule.replace('graph-of-', '') + "-")
-                self.save_html_and_open_html(
-                    dict_oval_trees, src, rule, out)
-            except NotChecked as error:
-                self.print_red_text(error)
-        return out
+    def _get_src_for_one_graph(self, rule, date=None):
+        return self.get_save_src(rule.replace('graph-of-', '') + "-")
 
     def prepare_data(self, rules):
         out = []
-        dict_oval_trees = dict()
+        oval_tree_dict = dict()
         if self.all_in_one:
             out = self._prepare_all_in_one_data(
-                rules, dict_oval_trees, out)
+                rules, oval_tree_dict, out)
         else:
-            out = self._prepare_data_by_one(rules, dict_oval_trees, out)
+            out = self._prepare_data_by_one(rules, oval_tree_dict, out)
         return out
 
     def prepare_parser(self):

--- a/oval_graph/json_to_html.py
+++ b/oval_graph/json_to_html.py
@@ -12,6 +12,7 @@ from .oval_node import restore_dict_to_tree
 from .converter import Converter
 from .exceptions import NotChecked
 
+
 class JsonToHtml(Client):
     def __init__(self, args):
         self.parser = None
@@ -22,7 +23,11 @@ class JsonToHtml(Client):
         self.source_filename = self.arg.source_filename
         self.rule_name = self.arg.rule_id
         self.out = self.arg.output
-        self.all_rules = self.arg.all
+        self.all_in_one = self.arg.all_in_one
+        if self.all_in_one:
+            self.all_rules = True
+        else:
+            self.all_rules = self.arg.all
         self.isatty = sys.stdout.isatty()
         self.show_failed_rules = False
         self.show_not_selected_rules = False
@@ -82,23 +87,51 @@ class JsonToHtml(Client):
         notselected_rules = []
         return self._check_rules_id(rules, notselected_rules)
 
-    def prepare_data(self, rules):
-        out = []
+    def create_dict_of_rule(self, rule):
+        self.oval_tree = self.load_json_to_oval_tree(rule)
+        return self.create_dict_of_oval_node(self.oval_tree)
+
+    def _prepare_all_in_one_data(self, rules, dict_oval_trees, out):
+        for rule in rules['rules']:
+            try:
+                dict_oval_trees[
+                    rule] = self.create_dict_of_rule(rule)
+            except NotChecked as error:
+                self.print_red_text(error)
+        src = self.get_save_src('rules')
+        self.save_html_with_all_rules_in_one(
+            dict_oval_trees, src, rules, out)
+        return out
+
+    def _prepare_data_by_one(self, rules, dict_oval_trees, out):
         for rule in rules["rules"]:
             try:
-                self.oval_tree = self.load_json_to_oval_tree(rule)
-                oval_tree_dict = self.create_dict_of_oval_node(
-                    self.oval_tree)
+                dict_oval_trees = self.create_dict_of_rule(rule)
                 src = self.get_save_src(
                     rule.replace('graph-of-', '') + "-")
                 self.save_html_and_open_html(
-                    oval_tree_dict, src, rule, out)
+                    dict_oval_trees, src, rule, out)
             except NotChecked as error:
                 self.print_red_text(error)
         return out
 
+    def prepare_data(self, rules):
+        out = []
+        dict_oval_trees = dict()
+        if self.all_in_one:
+            out = self._prepare_all_in_one_data(
+                rules, dict_oval_trees, out)
+        else:
+            out = self._prepare_data_by_one(rules, dict_oval_trees, out)
+        return out
+
     def prepare_parser(self):
         super().prepare_parser()
+        self.parser.add_argument(
+            '--all-in-one',
+            action="store_true",
+            default=False,
+            help="Processes all rules into one file.")
         self.parser.add_argument(
             '--off-web-browser',
             action="store_true",


### PR DESCRIPTION
This PR implements option `--all-in-one` to json-to-graph command. User can generate HTML file with all graphs. This PR changes the name of the files generated by the `json-to-graph` command. Removes the date of the HTML file was generated and leaves the date the JSON was created.
Fixes #123 #118 